### PR TITLE
GSLUX-537: Display metadata

### DIFF
--- a/src/components/layers-panel/catalog/Catalog.ts
+++ b/src/components/layers-panel/catalog/Catalog.ts
@@ -7,15 +7,19 @@ import { mapState } from '../../../state/map/map.state'
 import { Layer } from '../../../state/map/map.state.model'
 
 import './layer-tree/layer-tree-node.component'
+import './layer-metadata/layer-metadata.component'
 import { themesToLayerTree } from './layer-tree/layer-tree.mapper'
 import { LayerTreeNodeModel } from './layer-tree/layer-tree.model'
 import { layerTreeState } from './layer-tree/layer-tree.service'
+import { layerMetadataService } from './layer-metadata/layer-metadata.service'
+import { LayerMetadataModel } from './layer-metadata/layer-metadata.model'
 
 @customElement('lux-catalog')
 export class Catalog extends LitElement {
   @state()
   private layerTree: LayerTreeNodeModel | undefined
   private subscription = new Subscription()
+  @state() private layerMetadata: LayerMetadataModel
 
   constructor() {
     super()
@@ -55,12 +59,25 @@ export class Catalog extends LitElement {
     }
   }
 
+  private async displayLayerMetadata(event: Event) {
+    const node = (event as CustomEvent).detail
+    const layer = themesService.findById(node.id)
+    this.layerMetadata = await layerMetadataService.getLayerMetadata(
+      node,
+      layer
+    )
+  }
+
   render(): TemplateResult {
     return html`
+      <lux-layer-metadata
+        .layerMetadata="${this.layerMetadata}"
+      ></lux-layer-metadata>
       <lux-layer-tree-node
         .node="${this.layerTree}"
         @parent-toggle="${this.toggleParent}"
         @layer-toggle="${this.toggleLayer}"
+        @display-layer-metadata="${this.displayLayerMetadata}"
       ></lux-layer-tree-node>
     `
   }

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata-item.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata-item.component.ts
@@ -1,0 +1,23 @@
+import { html, LitElement, TemplateResult } from 'lit'
+import { customElement, property } from 'lit/decorators'
+import { i18nMixin } from '../../../../mixins/i18n-lit-element'
+
+@customElement('lux-layer-metadata-item')
+export class LayerMetadataItem extends i18nMixin(LitElement) {
+  @property({ type: String }) private label?: string
+  @property({ type: String }) private value?: string
+
+  render(): TemplateResult {
+    const content = this.value
+      ? html`
+          <dt>${this.label}</dt>
+          <dd>${this.value}</dd>
+        `
+      : html``
+    return content
+  }
+
+  override createRenderRoot() {
+    return this
+  }
+}

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
@@ -11,6 +11,7 @@ export class LayerMetadata extends i18nMixin(LitElement) {
   render(): TemplateResult {
     const content = this.layerMetadata
       ? html`
+          <button @click="${this.closeMetadata}">X</button>
           <h1>${i18next.t(`${this.layerMetadata.title}`)}</h1>
           <dl>
             <dt>${i18next.t('Name')}</dt>
@@ -43,6 +44,11 @@ export class LayerMetadata extends i18nMixin(LitElement) {
         `
       : html``
     return content
+  }
+
+  closeMetadata() {
+    const event = new CustomEvent(`close-layer-metadata`)
+    this.dispatchEvent(event)
   }
 
   override createRenderRoot() {

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
@@ -32,11 +32,11 @@ export class LayerMetadata extends i18nMixin(LitElement) {
                 <dt>${i18next.t("Contrainte d'utilisation")}</dt>
                 <dd>${this.layerMetadata.legalConstraints}</dd>
                 <dt>${i18next.t('Url vers la resource')}</dt>
-                <dd>${this.layerMetadata.link}</dd>
+                <dd>${this.layerMetadata.link.join(',')}</dd>
                 <dt>${i18next.t('Revision date')}</dt>
                 <dd>${this.layerMetadata.revisionDate}</dd>
                 <dt>${i18next.t('Keywords')}</dt>
-                <dd>${this.layerMetadata.keyword}</dd>
+                <dd>${this.layerMetadata.keyword.join(',')}</dd>
                 <dt>${i18next.t('Contact')}</dt>
                 <dd>${this.layerMetadata.responsibleParty}</dd>
                 <dt>${i18next.t('Link to the metadata')}</dt>

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
@@ -38,7 +38,7 @@ export class LayerMetadata extends i18nMixin(LitElement) {
                 <dt>${i18next.t('Keywords')}</dt>
                 <dd>${this.layerMetadata.keyword.join(',')}</dd>
                 <dt>${i18next.t('Contact')}</dt>
-                <dd>${this.layerMetadata.responsibleParty}</dd>
+                <dd>${this.layerMetadata.responsibleParty.join(',')}</dd>
                 <dt>${i18next.t('Link to the metadata')}</dt>
                 <dd>${this.layerMetadata.metadataLink}</dd>
                 <!--{{content.geonetworkBaseUrl}}/fre/catalog.search#/metadata/{{content.uid}}-->

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
@@ -1,0 +1,51 @@
+import i18next from 'i18next'
+import { html, LitElement, TemplateResult } from 'lit'
+import { customElement, property } from 'lit/decorators'
+import { i18nMixin } from '../../../../mixins/i18n-lit-element'
+import { LayerMetadataModel } from './layer-metadata.model'
+
+@customElement('lux-layer-metadata')
+export class LayerMetadata extends i18nMixin(LitElement) {
+  @property({ type: Object }) private layerMetadata?: LayerMetadataModel
+
+  render(): TemplateResult {
+    const content = this.layerMetadata
+      ? html`
+          <h1>${i18next.t(`${this.layerMetadata.title}`)}</h1>
+          <dl>
+            <dt>${i18next.t('Name')}</dt>
+            <dd>${this.layerMetadata.name}</dd>
+            <dt>${i18next.t('Description du Service')}</dt>
+            <dd>${this.layerMetadata.serviceDescription}</dd>
+            <!--WMS/WMTS-->
+            <dt>${i18next.t('Description')}</dt>
+            <dd>${this.layerMetadata.description}</dd>
+            <!--short_trusted_description || trusted_description-->
+            <dt>${i18next.t("Contrainte d'utilisation")}</dt>
+            <dd>${this.layerMetadata.legalConstraints}</dd>
+            <dt>${i18next.t('Url vers la resource')}</dt>
+            <dd>${this.layerMetadata.link}</dd>
+            <dt>${i18next.t('Revision date')}</dt>
+            <dd>${this.layerMetadata.revisionDate}</dd>
+            <dt>${i18next.t('Keywords')}</dt>
+            <dd>${this.layerMetadata.keyword}</dd>
+            <dt>${i18next.t('Contact')}</dt>
+            <dd>${this.layerMetadata.responsibleParty}</dd>
+            <dt>${i18next.t('Link to the metadata')}</dt>
+            <dd>${this.layerMetadata.metadataLink}</dd>
+            <!--{{content.geonetworkBaseUrl}}/fre/catalog.search#/metadata/{{content.uid}}-->
+            <dt>${i18next.t('The metadata is right now not available')}</dt>
+            <dd>${this.layerMetadata.isError}</dd>
+            <dt>${i18next.t('Legend')}</dt>
+            <dd>${this.layerMetadata.legendHtml}</dd>
+            <!--hasLegend-->
+          </dl>
+        `
+      : html``
+    return content
+  }
+
+  override createRenderRoot() {
+    return this
+  }
+}

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
@@ -11,36 +11,45 @@ export class LayerMetadata extends i18nMixin(LitElement) {
   render(): TemplateResult {
     const content = this.layerMetadata
       ? html`
-          <button @click="${this.closeMetadata}">X</button>
-          <h1>${i18next.t(`${this.layerMetadata.title}`)}</h1>
-          <dl>
-            <dt>${i18next.t('Name')}</dt>
-            <dd>${this.layerMetadata.name}</dd>
-            <dt>${i18next.t('Description du Service')}</dt>
-            <dd>${this.layerMetadata.serviceDescription}</dd>
-            <!--WMS/WMTS-->
-            <dt>${i18next.t('Description')}</dt>
-            <dd>${this.layerMetadata.description}</dd>
-            <!--short_trusted_description || trusted_description-->
-            <dt>${i18next.t("Contrainte d'utilisation")}</dt>
-            <dd>${this.layerMetadata.legalConstraints}</dd>
-            <dt>${i18next.t('Url vers la resource')}</dt>
-            <dd>${this.layerMetadata.link}</dd>
-            <dt>${i18next.t('Revision date')}</dt>
-            <dd>${this.layerMetadata.revisionDate}</dd>
-            <dt>${i18next.t('Keywords')}</dt>
-            <dd>${this.layerMetadata.keyword}</dd>
-            <dt>${i18next.t('Contact')}</dt>
-            <dd>${this.layerMetadata.responsibleParty}</dd>
-            <dt>${i18next.t('Link to the metadata')}</dt>
-            <dd>${this.layerMetadata.metadataLink}</dd>
-            <!--{{content.geonetworkBaseUrl}}/fre/catalog.search#/metadata/{{content.uid}}-->
-            <dt>${i18next.t('The metadata is right now not available')}</dt>
-            <dd>${this.layerMetadata.isError}</dd>
-            <dt>${i18next.t('Legend')}</dt>
-            <dd>${this.layerMetadata.legendHtml}</dd>
-            <!--hasLegend-->
-          </dl>
+          <div
+            class="fixed right-8 top-96 z-50 bg-white lux-modal w-[600px] p-3"
+            role="dialog"
+          >
+            <div class="lux-modal-header flex flex-row justify-between">
+              <h1>${i18next.t(`${this.layerMetadata.title}`)}</h1>
+              <button @click="${this.closeMetadata}">X</button>
+            </div>
+            <div class="pt-3">
+              <dl>
+                <dt>${i18next.t('Name')}</dt>
+                <dd>${this.layerMetadata.name}</dd>
+                <dt>${i18next.t('Description du Service')}</dt>
+                <dd>${this.layerMetadata.serviceDescription}</dd>
+                <!--WMS/WMTS-->
+                <dt>${i18next.t('Description')}</dt>
+                <dd>${this.layerMetadata.description}</dd>
+                <!--short_trusted_description || trusted_description-->
+                <dt>${i18next.t("Contrainte d'utilisation")}</dt>
+                <dd>${this.layerMetadata.legalConstraints}</dd>
+                <dt>${i18next.t('Url vers la resource')}</dt>
+                <dd>${this.layerMetadata.link}</dd>
+                <dt>${i18next.t('Revision date')}</dt>
+                <dd>${this.layerMetadata.revisionDate}</dd>
+                <dt>${i18next.t('Keywords')}</dt>
+                <dd>${this.layerMetadata.keyword}</dd>
+                <dt>${i18next.t('Contact')}</dt>
+                <dd>${this.layerMetadata.responsibleParty}</dd>
+                <dt>${i18next.t('Link to the metadata')}</dt>
+                <dd>${this.layerMetadata.metadataLink}</dd>
+                <!--{{content.geonetworkBaseUrl}}/fre/catalog.search#/metadata/{{content.uid}}-->
+                <dt>${i18next.t('The metadata is right now not available')}</dt>
+                <dd>${this.layerMetadata.isError}</dd>
+                <dt>${i18next.t('Legend')}</dt>
+                <dd>${this.layerMetadata.legendHtml}</dd>
+                <!--hasLegend-->
+              </dl>
+            </div>
+          </div>
         `
       : html``
     return content

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.component.ts
@@ -3,7 +3,7 @@ import { html, LitElement, TemplateResult } from 'lit'
 import { customElement, property } from 'lit/decorators'
 import { i18nMixin } from '../../../../mixins/i18n-lit-element'
 import { LayerMetadataModel } from './layer-metadata.model'
-
+import './layer-metadata-item.component'
 @customElement('lux-layer-metadata')
 export class LayerMetadata extends i18nMixin(LitElement) {
   @property({ type: Object }) private layerMetadata?: LayerMetadataModel
@@ -12,7 +12,7 @@ export class LayerMetadata extends i18nMixin(LitElement) {
     const content = this.layerMetadata
       ? html`
           <div
-            class="fixed right-8 top-96 z-50 bg-white lux-modal w-[600px] p-3"
+            class="fixed right-8 top-96 z-[100] bg-white lux-modal w-[600px] p-3"
             role="dialog"
           >
             <div class="lux-modal-header flex flex-row justify-between">
@@ -21,31 +21,52 @@ export class LayerMetadata extends i18nMixin(LitElement) {
             </div>
             <div class="pt-3">
               <dl>
-                <dt>${i18next.t('Name')}</dt>
-                <dd>${this.layerMetadata.name}</dd>
-                <dt>${i18next.t('Description du Service')}</dt>
-                <dd>${this.layerMetadata.serviceDescription}</dd>
-                <!--WMS/WMTS-->
-                <dt>${i18next.t('Description')}</dt>
-                <dd>${this.layerMetadata.description}</dd>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Name')}
+                  value=${this.layerMetadata.name}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Description du Service')}
+                  value=${this.layerMetadata.serviceDescription}
+                ></lux-layer-metadata-item>
                 <!--short_trusted_description || trusted_description-->
-                <dt>${i18next.t("Contrainte d'utilisation")}</dt>
-                <dd>${this.layerMetadata.legalConstraints}</dd>
-                <dt>${i18next.t('Url vers la resource')}</dt>
-                <dd>${this.layerMetadata.link.join(',')}</dd>
-                <dt>${i18next.t('Revision date')}</dt>
-                <dd>${this.layerMetadata.revisionDate}</dd>
-                <dt>${i18next.t('Keywords')}</dt>
-                <dd>${this.layerMetadata.keyword.join(',')}</dd>
-                <dt>${i18next.t('Contact')}</dt>
-                <dd>${this.layerMetadata.responsibleParty.join(',')}</dd>
-                <dt>${i18next.t('Link to the metadata')}</dt>
-                <dd>${this.layerMetadata.metadataLink}</dd>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Description')}
+                  value=${this.layerMetadata.description}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t("Contrainte d'utilisation")}
+                  value=${this.layerMetadata.legalConstraints}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Url vers la resource')}
+                  value=${this.layerMetadata.link?.join(',')}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Revision date')}
+                  value=${this.layerMetadata.revisionDate}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Keywords')}
+                  value=${this.layerMetadata.keyword?.join(',')}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Contact')}
+                  value=${this.layerMetadata.responsibleParty?.join(',')}
+                ></lux-layer-metadata-item>
                 <!--{{content.geonetworkBaseUrl}}/fre/catalog.search#/metadata/{{content.uid}}-->
-                <dt>${i18next.t('The metadata is right now not available')}</dt>
-                <dd>${this.layerMetadata.isError}</dd>
-                <dt>${i18next.t('Legend')}</dt>
-                <dd>${this.layerMetadata.legendHtml}</dd>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Link to the metadata')}
+                  value=${this.layerMetadata.metadataLink}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('The metadata is right now not available')}
+                  value=${this.layerMetadata.isError}
+                ></lux-layer-metadata-item>
+                <lux-layer-metadata-item
+                  label=${i18next.t('Legend')}
+                  value=${this.layerMetadata.legendHtml}
+                ></lux-layer-metadata-item>
                 <!--hasLegend-->
               </dl>
             </div>

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
@@ -7,7 +7,7 @@ export interface LayerMetadataModel {
   link: string[]
   revisionDate: string
   keyword: string[]
-  responsibleParty: string
+  responsibleParty: string[]
   metadataLink: string
   legendHtml?: HTMLElement
   hasLegend?: boolean

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
@@ -13,3 +13,9 @@ export interface LayerMetadataModel {
   hasLegend?: boolean
   isError?: boolean
 }
+
+export interface IdValues {
+  serviceType: 'WMS' | 'WMTS'
+  wmsUrl: string
+  layerName: string
+}

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
@@ -4,7 +4,7 @@ export interface LayerMetadataModel {
   serviceDescription: string
   description: string
   legalConstraints: string
-  link: string
+  link: string[]
   revisionDate: string
   keyword: string[]
   responsibleParty: string

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
@@ -1,0 +1,15 @@
+export interface LayerMetadataModel {
+  title?: string
+  name: string
+  serviceDescription: string
+  description: string
+  legalConstraints: string
+  link: string
+  revisionDate: string
+  keyword: string[]
+  responsibleParty: string
+  metadataLink: string
+  legendHtml?: HTMLElement
+  hasLegend?: boolean
+  isError: boolean
+}

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.model.ts
@@ -1,15 +1,15 @@
 export interface LayerMetadataModel {
   title?: string
   name: string
-  serviceDescription: string
-  description: string
-  legalConstraints: string
-  link: string[]
-  revisionDate: string
-  keyword: string[]
-  responsibleParty: string[]
-  metadataLink: string
+  serviceDescription?: string
+  description?: string
+  legalConstraints?: string
+  link?: string[]
+  revisionDate?: string
+  keyword?: string[]
+  responsibleParty?: string[]
+  metadataLink?: string
   legendHtml?: HTMLElement
   hasLegend?: boolean
-  isError: boolean
+  isError?: boolean
 }

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.service.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.service.ts
@@ -4,6 +4,7 @@ import { LayerTreeNodeModel } from '../layer-tree/layer-tree.model'
 import { LayerMetadataModel } from './layer-metadata.model'
 import {
   getMetadataLinks,
+  getResponsibleParty,
   isoLang2To3,
   stringToHtml,
 } from './layer-metadata.utils'
@@ -89,7 +90,9 @@ export class LayerMetadataService {
       link: getMetadataLinks(metadata.link),
       revisionDate: metadata.revisionDate, //TODO: handle date? (WMS, WMTS)
       keyword: metadata.keyword,
-      responsibleParty: metadata.responsibleParty,
+      responsibleParty: metadata.responsibleParty
+        ? getResponsibleParty(metadata.responsibleParty)
+        : [],
       metadataLink: `${this.geonetworkBaseUrl}/${isoLang2To3(
         language
       )}/catalog.search#/metadata/${metadataUid}`,

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.service.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.service.ts
@@ -1,0 +1,126 @@
+import i18next from 'i18next'
+import { ThemeNodeModel } from '../../../../services/themes/themes.model'
+import { Layer } from '../../../../state/map/map.state.model'
+import { LayerTreeNodeModel } from '../layer-tree/layer-tree.model'
+import { LayerMetadataModel } from './layer-metadata.model'
+import { isoLang2To3, stringToHtml } from './layer-metadata.utils'
+
+export class LayerMetadataService {
+  private geonetworkBaseUrl =
+    'https://geocatalogue.geoportail.lu/geonetwork/srv' //TODO: get from config
+  private legendBaseUrl = 'https://map.geoportail.lu/legends/get_html' //TODO: get from config
+  private localMetadataBaseUrl = 'https://map.geoportail.lu/getMetadata' //TODO: get from config or relative
+
+  async getLayerMetadata(
+    node: LayerTreeNodeModel,
+    layer?: ThemeNodeModel
+  ): Promise<LayerMetadataModel> {
+    console.log(node, layer)
+    let title
+    let localMetadata
+    if (!layer) {
+      //when is this case needed?
+      title = node.name
+      localMetadata = node.metadata // does not exist
+    } else {
+      title = layer.name
+      localMetadata = layer.metadata
+    }
+    const metadataUid = localMetadata.metadata_id
+
+    const layerId = layer.id
+    const legendName =
+      'legend_name' in localMetadata ? localMetadata.legend_name : ''
+    const currentLanguage = i18next.language
+
+    //TODO: handle WMTS, WMS
+    // if (localMetadata.isExternalWmts) {
+    //   promises_[promiseKey] = appWmtsHelper.getMetadata(metadataUid);
+    // } else if (localMetadata.isExternalWms) {
+    //   promises_[promiseKey] = appWmsHelper.getMetadata(metadataUid);
+    // } else {
+
+    let metadata = await this.getLocalMetadata(
+      this.localMetadataBaseUrl,
+      metadataUid,
+      currentLanguage
+    )
+    metadata = { ...metadata, title: title }
+
+    //could be sent in parallel
+    const legendHtml = await this.getLegendHtml(
+      this.legendBaseUrl,
+      legendName,
+      layerId,
+      currentLanguage
+    )
+    if (legendHtml) {
+      metadata = {
+        ...metadata,
+        legendHtml: legendHtml,
+        hasLegend: true,
+      }
+    } else {
+      metadata = {
+        ...metadata,
+        hasLegend: false,
+      }
+    }
+    return metadata
+  }
+
+  async getLocalMetadata(
+    baseUrl: string,
+    metadataUid: string,
+    language: string
+  ): Promise<LayerMetadataModel> {
+    const response = await fetch(
+      `${baseUrl}?lang=${language}&uid=${metadataUid}`
+    )
+    const metadata = (await response.json()).metadata
+
+    return {
+      name: metadata.title,
+      serviceDescription: metadata.serviceDescription,
+      description: metadata.abstract, //TODO: trustAsHtml? (currently short_trusted_description, trusted_description for teaser)
+      legalConstraints: metadata.legalConstraints,
+      link: metadata.link, //TODO: splitLink
+      revisionDate: metadata.revisionDate, //TODO: handle date? (WMS, WMTS)
+      keyword: metadata.keyword.join(', '),
+      responsibleParty: metadata.responsibleParty,
+      metadataLink: `${this.geonetworkBaseUrl}/${isoLang2To3(
+        language
+      )}/catalog.search#/metadata/${metadataUid}`,
+      isError: false, //TODO: catch errors
+    }
+  }
+
+  async getLegendHtml(
+    legendBaseUrl: string,
+    legendName: string,
+    layerId: number,
+    language: string
+  ) {
+    let legendHtml = undefined
+    const queryParams = {
+      lang: language,
+      ...(legendName && { name: legendName }),
+      ...(layerId && { id: layerId.toString() }),
+    }
+    if (queryParams.name && queryParams.lang) {
+      // TODO: handle high resolution screens?
+      // if ($window_.devicePixelRatio > 1) {
+      //   queryParams['dpi'] = $window_.devicePixelRatio * 96
+      // }
+      const legendUrl = `${legendBaseUrl}?${new URLSearchParams(
+        queryParams
+      ).toString()}`
+      const response = await fetch(legendUrl)
+      const legendString = await response.text()
+      if (legendString) legendHtml = stringToHtml(legendString)
+    }
+    return legendHtml
+  }
+}
+
+export const layerMetadataService = new LayerMetadataService()

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.service.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.service.ts
@@ -1,9 +1,12 @@
 import i18next from 'i18next'
 import { ThemeNodeModel } from '../../../../services/themes/themes.model'
-import { Layer } from '../../../../state/map/map.state.model'
 import { LayerTreeNodeModel } from '../layer-tree/layer-tree.model'
 import { LayerMetadataModel } from './layer-metadata.model'
-import { isoLang2To3, stringToHtml } from './layer-metadata.utils'
+import {
+  getMetadataLinks,
+  isoLang2To3,
+  stringToHtml,
+} from './layer-metadata.utils'
 
 export class LayerMetadataService {
   private geonetworkBaseUrl =
@@ -15,7 +18,6 @@ export class LayerMetadataService {
     node: LayerTreeNodeModel,
     layer?: ThemeNodeModel
   ): Promise<LayerMetadataModel> {
-    console.log(node, layer)
     let title
     let localMetadata
     if (!layer) {
@@ -84,9 +86,9 @@ export class LayerMetadataService {
       serviceDescription: metadata.serviceDescription,
       description: metadata.abstract, //TODO: trustAsHtml? (currently short_trusted_description, trusted_description for teaser)
       legalConstraints: metadata.legalConstraints,
-      link: metadata.link, //TODO: splitLink
+      link: getMetadataLinks(metadata.link),
       revisionDate: metadata.revisionDate, //TODO: handle date? (WMS, WMTS)
-      keyword: metadata.keyword.join(', '),
+      keyword: metadata.keyword,
       responsibleParty: metadata.responsibleParty,
       metadataLink: `${this.geonetworkBaseUrl}/${isoLang2To3(
         language

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.utils.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.utils.ts
@@ -1,0 +1,22 @@
+interface Lang {
+  fr: string
+  en: string
+  de: string
+  lb: string
+}
+
+export function isoLang2To3(code: string): string {
+  const lang: Lang = {
+    fr: 'fre',
+    en: 'eng',
+    de: 'ger',
+    lb: 'ltz',
+  }
+  return lang[code as keyof Lang]
+}
+
+export function stringToHtml(str: string): HTMLElement {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(str, 'text/html')
+  return doc.body
+}

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.utils.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.utils.ts
@@ -21,7 +21,7 @@ export function stringToHtml(str: string): HTMLElement {
   return doc.body
 }
 
-export function getMetadataLinks(link: string | string[]) {
+export function getMetadataLinks(link: string | string[]): string[] {
   const links = []
   function splitLink(link: string) {
     const currentLink = link.split('|')
@@ -38,4 +38,19 @@ export function getMetadataLinks(link: string | string[]) {
     splitLink(link)
   }
   return links
+}
+
+export function getResponsibleParty(
+  responsibleParty: string | string[]
+): string[] {
+  const pocs = Array.isArray(responsibleParty)
+    ? responsibleParty
+    : [responsibleParty]
+  const poc = pocs.filter(poc => poc.split('|')[1] === 'metadata')
+  return [
+    poc[0].split('|')[2],
+    poc[0].split('|')[5],
+    poc[0].split('|')[6],
+    poc[0].split('|')[7],
+  ]
 }

--- a/src/components/layers-panel/catalog/layer-metadata/layer-metadata.utils.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/layer-metadata.utils.ts
@@ -20,3 +20,22 @@ export function stringToHtml(str: string): HTMLElement {
   const doc = parser.parseFromString(str, 'text/html')
   return doc.body
 }
+
+export function getMetadataLinks(link: string | string[]) {
+  const links = []
+  function splitLink(link: string) {
+    const currentLink = link.split('|')
+    if (
+      currentLink[3] === 'WWW:LINK-1.0-http--link' &&
+      links.indexOf(currentLink[2]) === -1
+    ) {
+      links.push(currentLink[2])
+    }
+  }
+  if (Array.isArray(link)) {
+    link.forEach(splitLink, this)
+  } else {
+    splitLink(link)
+  }
+  return links
+}

--- a/src/components/layers-panel/catalog/layer-metadata/wms-helper.service.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/wms-helper.service.ts
@@ -1,0 +1,31 @@
+import { remoteLayersService } from '../remote-layers/remote-layers.service'
+
+export class WmsHelperService {
+  async getMetadata(id: string) {
+    const values = id.split('%2D').join('-').split('||')
+    const serviceType = values[0]
+    const wmsUrl = values[1]
+    const layerName = values[2]
+    console.assert(serviceType === 'WMS')
+    const wmsEndpoint = remoteLayersService.getWmsEndpoint(wmsUrl)
+    await wmsEndpoint.isReady()
+    const service = wmsEndpoint?.getServiceInfo()
+    const layer = wmsEndpoint?.getLayerByName(layerName)
+    return {
+      title: layer.title,
+      description: layer.abstract,
+      keywords: service.keywords,
+      accessConstraints: service.constraints,
+      serviceDescription: service.abstract,
+      /* The following attributes are present in production,
+       ** but no services could be found so far that filled them with values in production
+       ** values are not provided by ogc-client, and would need old code => can be ignored?
+       */
+      // pocs: undefined,
+      // revisionDate: '',
+      // language: undefined,
+      // onlineResource: undefined,
+    }
+  }
+}
+export const wmsHelper = new WmsHelperService()

--- a/src/components/layers-panel/catalog/layer-metadata/wms-helper.service.ts
+++ b/src/components/layers-panel/catalog/layer-metadata/wms-helper.service.ts
@@ -1,16 +1,13 @@
 import { remoteLayersService } from '../remote-layers/remote-layers.service'
+import { IdValues } from './layer-metadata.model'
 
 export class WmsHelperService {
-  async getMetadata(id: string) {
-    const values = id.split('%2D').join('-').split('||')
-    const serviceType = values[0]
-    const wmsUrl = values[1]
-    const layerName = values[2]
-    console.assert(serviceType === 'WMS')
-    const wmsEndpoint = remoteLayersService.getWmsEndpoint(wmsUrl)
+  async getMetadata(idValues: IdValues) {
+    console.assert(idValues.serviceType === 'WMS')
+    const wmsEndpoint = remoteLayersService.getWmsEndpoint(idValues.wmsUrl)
     await wmsEndpoint.isReady()
     const service = wmsEndpoint?.getServiceInfo()
-    const layer = wmsEndpoint?.getLayerByName(layerName)
+    const layer = wmsEndpoint?.getLayerByName(idValues.layerName)
     return {
       title: layer.title,
       description: layer.abstract,

--- a/src/components/layers-panel/catalog/layer-tree/layer-tree-node.component.ts
+++ b/src/components/layers-panel/catalog/layer-tree/layer-tree-node.component.ts
@@ -90,7 +90,10 @@ export class LayerTreeNode extends i18nMixin(LitElement) {
   renderLeaf(): TemplateResult {
     return html`
       <div class="flex bg-secondary text-tertiary px-2">
-        <button class="fa-solid fa-fw fa-fh fa-info leading-6"></button>
+        <button
+          class="fa-solid fa-fw fa-fh fa-info leading-6"
+          @click="${this.displayLayerMetadata}"
+        ></button>
         <button
           class="w-full text-left  ${this.node.checked ? 'font-bold' : ''}"
           @click="${this.toggleLayer}"
@@ -104,6 +107,14 @@ export class LayerTreeNode extends i18nMixin(LitElement) {
         </button>
       </div>
     `
+  }
+
+  displayLayerMetadata() {
+    const event = new CustomEvent(`display-layer-metadata`, {
+      bubbles: true,
+      detail: this.node,
+    })
+    this.dispatchEvent(event)
   }
 
   renderChildren(): TemplateResult {

--- a/src/components/layers-panel/catalog/remote-layers/remote-layers-mapper.ts
+++ b/src/components/layers-panel/catalog/remote-layers/remote-layers-mapper.ts
@@ -27,7 +27,7 @@ export function remoteLayersToLayerTreeMapper(
   depth = 0
 ): LayerTreeNodeModel {
   const { name, children } = node
-  const id = `WMS||${urlWms}${name}`.split('-').join('%2D')
+  const id = `WMS||${urlWms}||${name}`.split('-').join('%2D')
 
   return {
     id,

--- a/src/components/layers-panel/catalog/remote-layers/remote-layers.ts
+++ b/src/components/layers-panel/catalog/remote-layers/remote-layers.ts
@@ -13,12 +13,15 @@ import { layerTreeState } from '../layer-tree/layer-tree.service'
 import { mapState } from '../../../../state/map/map.state'
 import i18next from 'i18next'
 import { OgcClientWmsEndpoint } from './remote-layers.model'
+import { themesService } from '../../../../services/themes/themes.service'
+import { layerMetadataService } from '../layer-metadata/layer-metadata.service'
 
 @customElement('lux-remote-layers')
 export class RemoteLayer extends LitElement {
   @state() private wmsLayers: DropdownOptionModel[]
   @state() private layerTree: LayerTreeNodeModel | undefined
   @state() private isLoading = false
+  @state() private layerMetadata: LayerMetadataModel
   private subscription = new Subscription()
   private inputWmsUrl: string
   private currentWmsUrl: string
@@ -122,8 +125,23 @@ export class RemoteLayer extends LitElement {
     }
   }
 
+  private async displayLayerMetadata(node: LayerTreeNodeModel) {
+    const layer = themesService.findById(node.id)
+    console.log(node)
+    node = { ...node, isExternalWms: true }
+    this.layerMetadata = await layerMetadataService.getLayerMetadata(
+      node,
+      layer
+    )
+    // this.displayedMetadataNode = node  //TODO: move to UI state
+  }
+
   render(): TemplateResult {
     return html`
+      <lux-layer-metadata
+        .layerMetadata="${this.layerMetadata}"
+        @close-layer-metadata="${this.closeMetadata}"
+      ></lux-layer-metadata>
       <div
         class="absolute right-0 top-52 z-50 bg-white lux-modal w-[600px]"
         role="dialog"
@@ -195,6 +213,8 @@ export class RemoteLayer extends LitElement {
                     .node="${this.layerTree}"
                     @parent-toggle="${this.toggleParent}"
                     @layer-toggle="${this.toggleLayer}"
+                    @display-layer-metadata="${event =>
+                      this.displayLayerMetadata(event.detail)}"
                   ></lux-layer-tree-node>
                 </div>
               `

--- a/src/components/layers-panel/catalog/remote-layers/remote-layers.ts
+++ b/src/components/layers-panel/catalog/remote-layers/remote-layers.ts
@@ -127,8 +127,6 @@ export class RemoteLayer extends LitElement {
 
   private async displayLayerMetadata(node: LayerTreeNodeModel) {
     const layer = themesService.findById(node.id)
-    console.log(node)
-    node = { ...node, isExternalWms: true }
     this.layerMetadata = await layerMetadataService.getLayerMetadata(
       node,
       layer


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-537

### Description

PR queries layer metadata when clicking on "i" icon on the left of layer name. Currently, only works for local layers.

To-dos:

- [x] wms => maybe get more attributes and add legend? (examples for both could not be found on current production)
- [ ] wmts
- [x] update metadata when changing language
- [x] check/handle case when `layer?: ThemeNodeModel` undefined => double check if there is a different case other than external layers for this
- [x] split Link, responsibleParty
- [ ] handle date (wms, wmts) => does this attribute ever get retrieved?
- [ ] allow urls from config
- [ ] catch errors
- [ ] improve async
- [ ] safeHtml for description, legend? (like https://docs.angularjs.org/api/ng/service/$sce)
- [ ] legend: handle high resolution screens?


