### PR TITLE
fix husky pre-commit hooks after change from v4 to v8

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -60,13 +60,8 @@
     "vitest": "^0.25.3",
     "vue-tsc": "^1.0.9"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
-    "*.ts": [
+    "*.ts|*.vue": [
       "eslint --fix",
       "prettier --write"
     ]


### PR DESCRIPTION
### Description

husky pre-commit hooks for git were broken after husky upgrade v4 -> v8
https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/commit/7c1650921c357e5cd7a83bf35a5f340a1a274f16#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43

fixed now.