### PR TITLE
GSLUX-578: Display metadata from layermanager

### DIFF
--- a/src/components/catalog/catalog-tree.vue
+++ b/src/components/catalog/catalog-tree.vue
@@ -41,7 +41,7 @@ function toggleParent(node: LayerTreeNodeModel) {
 }
 
 function toggleLayer(node: LayerTreeNodeModel) {
-  layers.toggleLayer(parseInt(node.id, 10), !node.checked)
+  layers.toggleLayer(+node.id, !node.checked)
 }
 </script>
 

--- a/src/components/layer-manager/layer-item/layer-item-background.vue
+++ b/src/components/layer-manager/layer-item/layer-item-background.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{
   (e: 'clickEdit'): void
+  (e: 'clickInfo'): void
 }>()
 const { t, onClickInfo } = useLayer(props.layer, { emit })
 

--- a/src/components/layer-manager/layer-manager.vue
+++ b/src/components/layer-manager/layer-manager.vue
@@ -9,7 +9,9 @@ import { BLANK_BACKGROUNDLAYER } from '@/composables/background-layer/background
 
 import LayerManagerItemBackground from './layer-item/layer-item-background.vue'
 import LayerManagerItem from './layer-item/layer-item.vue'
+import { useMetadataStore } from '@/stores/metadata.store'
 
+const { setMetadataId } = useMetadataStore()
 const mapStore = useMapStore()
 const { bgLayer } = storeToRefs(mapStore)
 
@@ -48,10 +50,6 @@ function toggleAccordionItem(layer: Layer) {
   isLayerOpenId.value = isLayerOpenId.value !== layer.id ? layer.id : undefined
 }
 
-function toggleInfoLayer() {
-  console.info('clickInfo to implement')
-}
-
 function toggleEditionLayer() {
   console.info('clickEdit to implement')
 }
@@ -66,6 +64,7 @@ function toggleEditionLayer() {
         :isOpen="isLayerOpenId === layer.id"
         @clickRemove="removeLayer"
         @clickToggle="toggleAccordionItem"
+        @clickInfo="setMetadataId(layer.id)"
         @changeOpacity="changeOpacityLayer"
       >
       </layer-manager-item>
@@ -74,7 +73,7 @@ function toggleEditionLayer() {
       <layer-manager-item-background
         :layer="bgLayer || BLANK_BACKGROUNDLAYER"
         :showEditButton="!!bgLayer"
-        @clickInfo="toggleInfoLayer"
+        @clickInfo="() => bgLayer && setMetadataId(bgLayer.id)"
         @clickEdit="toggleEditionLayer"
       >
       </layer-manager-item-background>

--- a/src/components/layer-metadata/layer-metadata.vue
+++ b/src/components/layer-metadata/layer-metadata.vue
@@ -9,27 +9,29 @@ import { layerMetadataService } from '@/services/layer-metadata/layer-metadata.s
 import { LayerMetadataModel } from '@/services/layer-metadata/layer-metadata.model'
 
 const metadataStore = useMetadataStore()
-const { metadataTreeNode } = storeToRefs(metadataStore)
+const { metadataId } = storeToRefs(metadataStore)
 const { t, i18next } = useTranslation()
 const layerMetadata: Ref<LayerMetadataModel | undefined> = ref()
 
-watch(metadataTreeNode, async node => {
-  layerMetadata.value = node
-    ? await layerMetadataService.getLayerMetadata(node, i18next.language)
+watch(metadataId, async id => {
+  layerMetadata.value = id
+    ? await layerMetadataService.getLayerMetadata(id, i18next.language)
     : undefined
 })
 
 onMounted(() => {
-  i18next.on('languageChanged', () => {
-    if (metadataTreeNode.value) {
-      //also trigger request if metadataTreeNode does not change
-      metadataStore.setMetadataTreeNode({ ...metadataTreeNode.value })
+  i18next.on('languageChanged', async () => {
+    if (metadataId.value) {
+      layerMetadata.value = await layerMetadataService.getLayerMetadata(
+        metadataId.value,
+        i18next.language
+      )
     }
   })
 })
 
 function closeLayerMetadata() {
-  metadataStore.clearMetadataTreeNode()
+  metadataStore.clearMetadataId()
 }
 </script>
 

--- a/src/components/layer-tree/layer-tree-node.vue
+++ b/src/components/layer-tree/layer-tree-node.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useTranslation()
-const { setMetadataTreeNode } = useMetadataStore()
+const { setMetadataId } = useMetadataStore()
 const isParent = !!props.node.children
 const isRoot = props.node.depth === 0
 const isMaxDepth = props.node.depth >= 10
@@ -89,7 +89,7 @@ function toggleParent(node: LayerTreeNodeModel) {
   <div v-else class="flex text-tertiary pr-2">
     <button
       class="self-start before:text-[.85rem] before:transform before:translate-y-[.1rem] before:inline-block before:content-['\f129'] fa-solid fa-fw fa-fh fa-info"
-      @click="setMetadataTreeNode(node)"
+      @click="setMetadataId(node.id)"
     ></button>
     <button
       class="w-full text-left"

--- a/src/components/layer-tree/layer-tree.model.ts
+++ b/src/components/layer-tree/layer-tree.model.ts
@@ -1,7 +1,9 @@
+import { LayerId } from '@/stores/map.store.model'
+
 export type LayerTreeToggleProperty = 'checked' | 'expanded'
 
 export interface LayerTreeNodeModel {
-  id: string
+  id: LayerId
   name: string
   checked: boolean
   expanded: boolean

--- a/src/components/layer-tree/layer-tree.service.ts
+++ b/src/components/layer-tree/layer-tree.service.ts
@@ -1,4 +1,4 @@
-import type { Layer } from '@/stores/map.store.model'
+import type { Layer, LayerId } from '@/stores/map.store.model'
 import type {
   LayerTreeNodeModel,
   LayerTreeToggleProperty,
@@ -6,7 +6,7 @@ import type {
 
 export class LayerTreeService {
   toggleNode(
-    id: string,
+    id: LayerId,
     node: LayerTreeNodeModel,
     propertyName: LayerTreeToggleProperty
   ): LayerTreeNodeModel {

--- a/src/components/remote-layers/remote-layers.mapper.ts
+++ b/src/components/remote-layers/remote-layers.mapper.ts
@@ -1,5 +1,5 @@
 import { useMapStore } from '@/stores/map.store'
-import { Layer, LayerImageType } from '@/stores/map.store.model'
+import { Layer, LayerId, LayerImageType } from '@/stores/map.store.model'
 import { LayerTreeNodeModel } from '@/components/layer-tree/layer-tree.model'
 import {
   OgcClientWmsLayerSummary,
@@ -59,7 +59,7 @@ export function remoteLayerToLayer({
   url,
   remoteLayer,
 }: {
-  id: string
+  id: LayerId
   url: string
   remoteLayer: OgcClientWmsLayerFull
 }): Layer {

--- a/src/composables/layers/layers.composable.ts
+++ b/src/composables/layers/layers.composable.ts
@@ -1,6 +1,6 @@
 import i18next from 'i18next'
 
-import type { Layer } from '@/stores/map.store.model'
+import type { Layer, LayerId } from '@/stores/map.store.model'
 import { useMapStore } from '@/stores/map.store'
 import { useThemeStore } from '@/stores/config.store'
 import useThemes from '@/composables/themes/themes.composable'
@@ -59,7 +59,7 @@ export default function useLayers() {
     }
   }
 
-  function toggleLayer(id: number, show = true) {
+  function toggleLayer(id: LayerId, show = true) {
     const themeStore = useThemeStore()
     const mapStore = useMapStore()
 

--- a/src/composables/themes/themes.composable.ts
+++ b/src/composables/themes/themes.composable.ts
@@ -1,10 +1,11 @@
 import type { ConfigModel, ThemeNodeModel } from './themes.model'
 import { themesApiFixture } from '@/__fixtures__/themes.api.fixture'
 import { useThemeStore } from '@/stores/config.store'
+import { LayerId } from '@/stores/map.store.model'
 
 export default function useThemes() {
   function findById(
-    id: number,
+    id: LayerId,
     node?: ThemeNodeModel
   ): ThemeNodeModel | undefined {
     const { theme } = useThemeStore()
@@ -22,7 +23,7 @@ export default function useThemes() {
     }
   }
 
-  function findBgLayerById(id: number) {
+  function findBgLayerById(id: LayerId) {
     const { bgLayers } = useThemeStore()
 
     return bgLayers.find(l => l.id === id)

--- a/src/services/layer-metadata/layer-metadata.service.ts
+++ b/src/services/layer-metadata/layer-metadata.service.ts
@@ -8,6 +8,7 @@ import {
 } from './layer-metadata.utils'
 import { wmsHelper } from '../common/wms.helper'
 import useThemes from '../../composables/themes/themes.composable'
+import { LayerId } from '@/stores/map.store.model'
 
 export class LayerMetadataService {
   // TODO: get urls from a config
@@ -18,7 +19,7 @@ export class LayerMetadataService {
   private localMetadataBaseUrl = 'https://map.geoportail.lu/getMetadata'
 
   async getLayerMetadata(
-    id: string | number,
+    id: LayerId,
     currentLanguage: string
   ): Promise<LayerMetadataModel> {
     const layer: ThemeNodeModel | undefined =

--- a/src/services/layer-metadata/layer-metadata.service.ts
+++ b/src/services/layer-metadata/layer-metadata.service.ts
@@ -1,5 +1,4 @@
 import { ThemeNodeModel } from '@/composables/themes/themes.model'
-import { LayerTreeNodeModel } from '@/components/layer-tree/layer-tree.model'
 import { IdValues, LayerMetadataModel } from './layer-metadata.model'
 import {
   getMetadataLinks,
@@ -19,12 +18,11 @@ export class LayerMetadataService {
   private localMetadataBaseUrl = 'https://map.geoportail.lu/getMetadata'
 
   async getLayerMetadata(
-    node: LayerTreeNodeModel,
+    id: string | number,
     currentLanguage: string
   ): Promise<LayerMetadataModel> {
-    const layer: ThemeNodeModel | undefined = useThemes().findById(
-      parseInt(node.id, 10)
-    )
+    const layer: ThemeNodeModel | undefined =
+      useThemes().findById(+id) || useThemes().findBgLayerById(+id)
     let localMetadata
     let metadata
     if (layer) {
@@ -66,7 +64,7 @@ export class LayerMetadataService {
           })
     } else {
       // is this case needed for another case than external layers (which have no theme node in theme service)?
-      const values = node.id.split('%2D').join('-').split('||')
+      const values = String(id).split('%2D').join('-').split('||')
       const idValues: IdValues = {
         serviceType: values[0] as 'WMS' | 'WMTS',
         wmsUrl: values[1],

--- a/src/stores/metadata.store.ts
+++ b/src/stores/metadata.store.ts
@@ -1,24 +1,23 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref, Ref } from 'vue'
-import { LayerTreeNodeModel } from '@/components/layer-tree/layer-tree.model'
 
 export const useMetadataStore = defineStore(
   'metadata',
   () => {
-    const metadataTreeNode: Ref<LayerTreeNodeModel | undefined> = ref()
+    const metadataId: Ref<string | number | undefined> = ref()
 
-    function setMetadataTreeNode(node: LayerTreeNodeModel) {
-      metadataTreeNode.value = node
+    function setMetadataId(id: string | number) {
+      metadataId.value = id
     }
 
-    function clearMetadataTreeNode() {
-      metadataTreeNode.value = undefined
+    function clearMetadataId() {
+      metadataId.value = undefined
     }
 
     return {
-      metadataTreeNode,
-      setMetadataTreeNode,
-      clearMetadataTreeNode,
+      metadataId,
+      setMetadataId,
+      clearMetadataId,
     }
   },
   {}

--- a/src/stores/metadata.store.ts
+++ b/src/stores/metadata.store.ts
@@ -1,12 +1,13 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref, Ref } from 'vue'
+import { LayerId } from './map.store.model'
 
 export const useMetadataStore = defineStore(
   'metadata',
   () => {
-    const metadataId: Ref<string | number | undefined> = ref()
+    const metadataId: Ref<LayerId | undefined> = ref()
 
-    function setMetadataId(id: string | number) {
+    function setMetadataId(id: LayerId) {
       metadataId.value = id
     }
 


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-578

### Description

PR displays metadata from layermanager (which was lost when refactoring #26). Now also handles bgLayers which was not the case before.

It refactors the metadata store to only store the metadata id to work with nodes and layers.



