### PR TITLE
GSLUX-592: Style Editor Medium

### DIFF
--- a/public/assets/locales/client.de.json
+++ b/public/assets/locales/client.de.json
@@ -25,6 +25,7 @@
   "A4 portrait": "A4 hoch ",
   "Abort": "Abbrechen",
   "Access constraints :": "Zugangsbedingungen :",
+  "Activate categories": "Eine Kategorie anzeigen",
   "Activate offline mode": "Offline-Modus einschalten",
   "Activer Google Streetview": "Google Street View aktivieren ",
   "Add external data": "Externe Daten hinzufügen",
@@ -324,6 +325,7 @@
   "Search Maps": "Karten suchen",
   "Select a style": "Wählen Sie eine Darstellung",
   "Select style: {{styleName}}": "",
+  "Select a colour for every theme": "Wählen Sie eine Farbe pro Thematik aus",
   "Section": "Sektion",
   "Section cadastrale": "Kadastersektion",
   "Send feedback to support team": "Feedback an das Support Team senden",
@@ -332,6 +334,7 @@
   "Show extent": "Ausdehnung anzeigen",
   "Show long url": "Lange URL anzeigen",
   "Show orientation": "Ausrichtung anzeigen",
+  "Show or hide {{ thematicName }}": "Show or hide {{ thematicName }}",
   "Size": "Größe",
   "Sort \"{{layerName}}\" in the list": "Sort \"{{layerName}}\" in the list",
   "Statut": "Status",
@@ -1711,5 +1714,12 @@
   "Dark sand": "Braun",
   "Kids": "Bunt",
   "Light mauve": "Magenta",
-  "Light Blue": "Blau"
+  "Light Blue": "Blau",
+  "Roads primary": "Hauptstraßen",
+  "Roads secondary": "Nebenstraßen",
+  "Vegetation": "Vegetation",
+  "Buildings": "Gebäude",
+  "Water": "Hydrologie",
+  "Arrière-fond": "Hintergrund",
+  "Hillshade": "Relief"
 }

--- a/public/assets/locales/client.en.json
+++ b/public/assets/locales/client.en.json
@@ -24,6 +24,7 @@
   "A4 portrait": "A4 portrait",
   "Abort": "Abort",
   "Access constraints :": "Access constraints",
+  "Activate categories": "Activate categories",
   "Activate offline mode": "Activate offline mode",
   "Activer Google Streetview": "Enable Google Street View",
   "Add external data": "Add external data",
@@ -323,6 +324,7 @@
   "Search Maps": "Search Maps",
   "Select a style": "Select a style",
   "Select style: {{styleName}}": "Select style: {{styleName}}",
+  "Select a colour for every theme": "Select a colour for every theme",
   "Section": "Section",
   "Section cadastrale": "Cadastral section",
   "Send feedback to support team": "Send feedback to support team",
@@ -331,6 +333,7 @@
   "Show extent": "Show extent",
   "Show long url": "Show long URL",
   "Show orientation": "Show orientation",
+  "Show or hide {{ thematicName }}": "Show or hide {{ thematicName }}",
   "Size": "Size",
   "Sort \"{{layerName}}\" in the list": "Sort \"{{layerName}}\" in the list",
   "Statut": "Status",
@@ -1710,5 +1713,12 @@
   "Dark sand": "Brown",
   "Kids": "Colourful",
   "Light mauve": "Magenta",
-  "Light Blue": "Blue"
+  "Light Blue": "Blue",
+  "Roads primary": "Main roads",
+  "Roads secondary": "Secondary roads",
+  "Vegetation": "Vegetation",
+  "Buildings": "Buildings",
+  "Water": "Hydrology",
+  "Arrière-fond": "Background",
+  "Hillshade": "Relief"
 }

--- a/public/assets/locales/client.fr.json
+++ b/public/assets/locales/client.fr.json
@@ -25,6 +25,7 @@
   "A4 portrait": "A4 portrait",
   "Abort": "Abandonner",
   "Access constraints :": "Contraintes d'utilisation",
+  "Activate categories": "Afficher une catégorie",
   "Activate offline mode": "Activer mode hors-ligne",
   "Activer Google Streetview": "Activer Google Street View",
   "Add external data": "Ajouter des données externes",
@@ -324,6 +325,7 @@
   "Search Maps": "Chercher carte",
   "Select a style": "Sélectionner un style",
   "Select style: {{styleName}}": "Sélectionner le style : {{styleName}}",
+  "Select a colour for every theme": "Sélectionner une couleur par thématique",
   "Section": "Section",
   "Section cadastrale": "Section cadastrale",
   "Send feedback to support team": "Envoyer un feedback à l'équipe de support",
@@ -333,6 +335,7 @@
   "Show long url": "Montrer URL longue",
   "Show orientation": "Afficher orientation",
   "Simple style editor": "Simple style editor",
+  "Show or hide {{ thematicName }}": "Afficher ou cacher la thématique {{ thematicName }}",
   "Size": "Taille",
   "Sort \"{{layerName}}\" in the list": "Déplacer le calque \"{{layerName}}\" dans la liste",
   "Statut": "Statut",
@@ -1712,5 +1715,12 @@
   "Dark sand": "Brun",
   "Kids": "Colorié",
   "Light mauve": "Magenta",
-  "Light Blue": "Bleu"
+  "Light Blue": "Bleu",
+  "Roads primary": "Routes primaires",
+  "Roads secondary": "Routes secondaires",
+  "Vegetation": "Végétation",
+  "Buildings": "Bâtiments",
+  "Water": "Hydrologie",
+  "Arrière-fond": "Arrière-fond",
+  "Hillshade": "Relief"
 }

--- a/public/assets/locales/client.lb.json
+++ b/public/assets/locales/client.lb.json
@@ -24,6 +24,7 @@
   "A4 portrait": "A4 Portrait",
   "Abort": "Ënnerbriechen",
   "Access constraints :": "Zougangslimitatiounen :",
+  "Activate categories": "Eng Kategorie uweisen",
   "Activate offline mode": "Offline-Modus aktivéiren",
   "Activer Google Streetview": "Aktivéiert Google Street View",
   "Add external data": "Extern Date bäilueden",
@@ -323,6 +324,7 @@
   "Search Maps": "Kaarten sichen",
   "Select a style": "Wielt ee Stil",
   "Select style: {{styleName}}": "",
+  "Select a colour for every theme": "Wielt eng Faarf fir all Thematik",
   "Section": "Sectioun",
   "Section cadastrale": "Kadastersektioun",
   "Send feedback to support team": "Feedback un d'Support Team schécken",
@@ -331,6 +333,7 @@
   "Show extent": "Ausdehnung uweisen",
   "Show long url": "Laang URL uweisen",
   "Show orientation": "Orientatioun uweisen",
+  "Show or hide {{ thematicName }}": "Show or hide {{ thematicName }}",
   "Size": "Gréisst",
   "Sort \"{{layerName}}\" in the list": "Sort \"{{layerName}}\" in the list",
   "Statut": "Status",
@@ -1710,5 +1713,12 @@
   "Dark sand": "Brong",
   "Kids": "Faarweg",
   "Light mauve": "Magenta",
-  "Light Blue": "Blo"
+  "Light Blue": "Blo",
+  "Roads primary": "Haaptstroossen",
+  "Roads secondary": "Niewestroossen",
+  "Vegetation": "Vegetatioun",
+  "Buildings": "Gebaier",
+  "Water": "Hydrologie",
+  "Arrière-fond": "Hannergrond",
+  "Hillshade": "Relief"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,12 +15,14 @@ import StyleSelector from '@/components/style-selector/style-selector.vue'
 import { statePersistorLayersService } from '@/services/state-persistor/state-persistor-layers.service'
 import { statePersistorThemeService } from '@/services/state-persistor/state-persistor-theme.service'
 import { statePersistorLayersOpenService } from '@/services/state-persistor/state-persistor-layersopen.service'
+import { statePersistorStyleService } from '@/services/state-persistor/state-persistor-bgstyle.service'
 import { useAppStore } from '@/stores/app.store'
 import useMap from './composables/map/map.composable'
 
 statePersistorLayersService.bootstrap()
 statePersistorThemeService.bootstrap()
 statePersistorLayersOpenService.bootstrapLayersOpen()
+statePersistorStyleService.bootstrapStyle()
 
 const { layersOpen } = storeToRefs(useAppStore())
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import BackgroundSelector from '@/components/background-selector/background-sele
 
 import LayerPanel from '@/components/layer-panel/layer-panel.vue'
 import MapContainer from '@/components/map/map-container.vue'
+import StyleSelector from '@/components/style-selector/style-selector.vue'
 
 import { statePersistorLayersService } from '@/services/state-persistor/state-persistor-layers.service'
 import { statePersistorThemeService } from '@/services/state-persistor/state-persistor-theme.service'
@@ -37,6 +38,9 @@ watch(layersOpen, () =>
       <!--side bar-->
       <div v-if="layersOpen" class="w-full sm:w-80 bg-secondary z-10">
         <layer-panel></layer-panel>
+      </div>
+      <div v-if="styleEditorOpen" class="w-80 bg-primary">
+        <style-selector />
       </div>
       <div class="grow bg-blue-100">
         <map-container></map-container>

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@ statePersistorThemeService.bootstrap()
 statePersistorLayersOpenService.bootstrapLayersOpen()
 statePersistorStyleService.bootstrapStyle()
 
-const { layersOpen } = storeToRefs(useAppStore())
+const { layersOpen, styleEditorOpen } = storeToRefs(useAppStore())
 
 watch(layersOpen, () =>
   setTimeout(() => {

--- a/src/__fixtures__/background.config.fixture.ts
+++ b/src/__fixtures__/background.config.fixture.ts
@@ -4,7 +4,9 @@ export const bgConfigFixture = () => ({
       // basemap_2015_global
       icon_id: 'route',
       vector_id: 'roadmap',
+      simple_style_class: 'road',
       medium_style_class: 'road',
+      expert_style_class: 'maputnik',
       id: 556,
       is_default: true,
     },
@@ -13,6 +15,7 @@ export const bgConfigFixture = () => ({
       icon_id: 'topo',
       vector_id: 'topomap',
       medium_style_class: 'topo',
+      expert_style_class: 'maputnik',
       id: 529,
     },
     {
@@ -20,6 +23,7 @@ export const bgConfigFixture = () => ({
       icon_id: 'topo_bw',
       vector_id: 'topomap_gray',
       medium_style_class: 'topo',
+      expert_style_class: 'maputnik',
       id: 502,
     },
     {
@@ -38,88 +42,90 @@ export const bgConfigFixture = () => ({
   bg_layer_theme_defaults: {
     tourisme: 502,
   },
-  simple_styles: [
+  simple_styles: {
     // ['Roads primary','Roads secondary','Vegetation','Buildings','Water', 'Background']
     // ['#bc1515', '#bcffdd','#bcffdd','#bc1133','#bc1133', '#f2f2f2'],
-    {
-      unlocalized_label: 'Light grey',
-      hillshade: false,
-      colors: [
-        '#ffffff',
-        '#ffffff',
-        '#d6e0d7',
-        '#e1e1e1',
-        '#cccccc',
-        '#f2f2f2',
-      ],
-      selected: false,
-    },
-    {
-      unlocalized_label: 'Dark grey',
-      hillshade: false,
-      colors: [
-        '#808080',
-        '#808080',
-        '#494b4a',
-        '#505052',
-        '#232426',
-        '#454545',
-      ],
-      selected: false,
-    },
-    {
-      unlocalized_label: 'Dark sand',
-      hillshade: false,
-      colors: [
-        '#9e9375',
-        '#9e9375',
-        '#6b6249',
-        '#403928',
-        '#b8aa84',
-        '#1a1814',
-      ],
-      selected: false,
-    },
-    {
-      unlocalized_label: 'Kids',
-      hillshade: false,
-      colors: [
-        '#f9c50d',
-        '#ffffff',
-        '#839836',
-        '#d6d3ce',
-        '#2a5ba8',
-        '#eeeeee',
-      ],
-      selected: false,
-    },
-    {
-      unlocalized_label: 'Light mauve',
-      hillshade: false,
-      colors: [
-        '#f3edf5',
-        '#f3edf5',
-        '#9d7da8',
-        '#caa9d1',
-        '#613b5c',
-        '#e5d3e6',
-      ],
-      selected: false,
-    },
-    {
-      unlocalized_label: 'Light Blue',
-      hillshade: false,
-      colors: [
-        '#dceaf5',
-        '#dceaf5',
-        '#5598cf',
-        '#81b7e3',
-        '#3b576e',
-        '#b6cde0',
-      ],
-      selected: false,
-    },
-  ],
+    road: [
+      {
+        unlocalized_label: 'Light grey',
+        hillshade: false,
+        colors: [
+          '#ffffff',
+          '#ffffff',
+          '#d6e0d7',
+          '#e1e1e1',
+          '#cccccc',
+          '#f2f2f2',
+        ],
+        selected: false,
+      },
+      {
+        unlocalized_label: 'Dark grey',
+        hillshade: false,
+        colors: [
+          '#808080',
+          '#808080',
+          '#494b4a',
+          '#505052',
+          '#232426',
+          '#454545',
+        ],
+        selected: false,
+      },
+      {
+        unlocalized_label: 'Dark sand',
+        hillshade: false,
+        colors: [
+          '#9e9375',
+          '#9e9375',
+          '#6b6249',
+          '#403928',
+          '#b8aa84',
+          '#1a1814',
+        ],
+        selected: false,
+      },
+      {
+        unlocalized_label: 'Kids',
+        hillshade: false,
+        colors: [
+          '#f9c50d',
+          '#ffffff',
+          '#839836',
+          '#d6d3ce',
+          '#2a5ba8',
+          '#eeeeee',
+        ],
+        selected: false,
+      },
+      {
+        unlocalized_label: 'Light mauve',
+        hillshade: false,
+        colors: [
+          '#f3edf5',
+          '#f3edf5',
+          '#9d7da8',
+          '#caa9d1',
+          '#613b5c',
+          '#e5d3e6',
+        ],
+        selected: false,
+      },
+      {
+        unlocalized_label: 'Light Blue',
+        hillshade: false,
+        colors: [
+          '#dceaf5',
+          '#dceaf5',
+          '#5598cf',
+          '#81b7e3',
+          '#3b576e',
+          '#b6cde0',
+        ],
+        selected: false,
+      },
+    ],
+  },
   medium_default_styles: {
     road: [
       {

--- a/src/components/layer-manager/layer-manager.vue
+++ b/src/components/layer-manager/layer-manager.vue
@@ -3,25 +3,26 @@ import { computed, onMounted, ShallowRef, shallowRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import Sortable, { SortableEvent } from 'sortablejs'
 
+import { useAppStore } from '@/stores/app.store'
 import { useMapStore } from '@/stores/map.store'
 import type { Layer, LayerId } from '@/stores/map.store.model'
+import { useMetadataStore } from '@/stores/metadata.store'
 import { BLANK_BACKGROUNDLAYER } from '@/composables/background-layer/background-layer.model'
 
 import LayerManagerItemBackground from './layer-item/layer-item-background.vue'
 import LayerManagerItem from './layer-item/layer-item.vue'
-import SimpleStyleSelector from '../style-selector/simple-style-selector.vue'
-import { useMetadataStore } from '@/stores/metadata.store'
-
-const ROAD_MAP_ID = 556
 
 const { setMetadataId } = useMetadataStore()
 const mapStore = useMapStore()
+const appStore = useAppStore()
 const { bgLayer } = storeToRefs(mapStore)
 
 const layers = computed(() => [...mapStore.layers].reverse())
 const isLayerOpenId: ShallowRef<LayerId | undefined> = shallowRef()
-const isStyleEditorOpen: ShallowRef<boolean> = shallowRef(false)
 const draggableClassName = 'drag-handle'
+const bgLayerIsEditable = computed(
+  () => bgLayer.value?.id === 556 || bgLayer.value?.id === 529
+) // TODO: Temp, remove when is Editable done
 
 onMounted(() => {
   const sortableLayers = document.getElementById('sortable-layers')
@@ -55,7 +56,7 @@ function toggleAccordionItem(layer: Layer) {
 }
 
 function toggleEditionLayer() {
-  isStyleEditorOpen.value = !isStyleEditorOpen.value
+  appStore.toggleStyleEditorPanel()
 }
 </script>
 
@@ -81,16 +82,11 @@ function toggleEditionLayer() {
     <li>
       <layer-manager-item-background
         :layer="bgLayer || BLANK_BACKGROUNDLAYER"
-        :showEditButton="bgLayer?.id === ROAD_MAP_ID"
+        :showEditButton="bgLayerIsEditable"
         @clickInfo="() => bgLayer && setMetadataId(bgLayer.id)"
         @clickEdit="toggleEditionLayer"
       >
       </layer-manager-item-background>
-      <!-- TODO: add medium and advanced style editors -->
-      <simple-style-selector
-        :is-open="isStyleEditorOpen && bgLayer?.id === ROAD_MAP_ID"
-      >
-      </simple-style-selector>
     </li>
   </ul>
 </template>

--- a/src/components/layer-manager/layer-manager.vue
+++ b/src/components/layer-manager/layer-manager.vue
@@ -8,6 +8,7 @@ import { useMapStore } from '@/stores/map.store'
 import type { Layer, LayerId } from '@/stores/map.store.model'
 import { useMetadataStore } from '@/stores/metadata.store'
 import { BLANK_BACKGROUNDLAYER } from '@/composables/background-layer/background-layer.model'
+import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
 
 import LayerManagerItemBackground from './layer-item/layer-item-background.vue'
 import LayerManagerItem from './layer-item/layer-item.vue'
@@ -16,13 +17,14 @@ const { setMetadataId } = useMetadataStore()
 const mapStore = useMapStore()
 const appStore = useAppStore()
 const { bgLayer } = storeToRefs(mapStore)
+const styles = useMvtStyles()
 
 const layers = computed(() => [...mapStore.layers].reverse())
 const isLayerOpenId: ShallowRef<LayerId | undefined> = shallowRef()
 const draggableClassName = 'drag-handle'
-const bgLayerIsEditable = computed(
-  () => bgLayer.value?.id === 556 || bgLayer.value?.id === 529
-) // TODO: Temp, remove when is Editable done
+const bgLayerIsEditable = computed(() =>
+  styles.isLayerStyleEditable(bgLayer.value)
+)
 
 onMounted(() => {
   const sortableLayers = document.getElementById('sortable-layers')

--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -16,9 +16,9 @@ const { setLayersOpen } = useAppStore()
 <template>
   <div data-cy="layerPanel" class="flex flex-col h-full">
     <div class="h-20 shrink-0 flex justify-between lux-panel-title">
-      <span>
+      <h2>
         {{ t('Layers', { ns: 'client' }) }}
-      </span>
+      </h2>
       <span
         ><button
           @click="() => setLayersOpen(false)"

--- a/src/components/style-selector/medium-style-item.vue
+++ b/src/components/style-selector/medium-style-item.vue
@@ -1,28 +1,30 @@
 <script setup lang="ts">
 import { useTranslation } from 'i18next-vue'
+import { StyleItem } from '@/composables/mvt-styles/mvt-styles.model'
 
 const { t } = useTranslation()
 const props = defineProps<{
-  color?: string
-  thematicName: string
+  style: StyleItem
+  colorEditable: boolean
 }>()
 </script>
 
 <template>
   <div class="flex w-full items-center">
-    <label for="colorId" class="w-40">{{ t(props.thematicName) }}</label>
+    <label for="colorId" class="w-40">{{ t(style.label) }}</label>
     <div class="grow">
       <input
-        v-if="color"
+        v-if="colorEditable && props.style.color"
         id="colorId"
         type="color"
         class="w-11 h-5 py-[1px] px-[2px]"
-        :value="props.color"
+        :value="props.style.color"
       />
     </div>
     <input
       type="checkbox"
       class="flex-none mr-3"
+      :checked="props.style.visible"
       :aria-label="
         t('Show or hide {{ thematicName }}', {
           thematicName: props.thematicName,

--- a/src/components/style-selector/medium-style-item.vue
+++ b/src/components/style-selector/medium-style-item.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+
+const { t } = useTranslation()
+const props = defineProps<{
+  color?: string
+  thematicName: string
+}>()
+</script>
+
+<template>
+  <div class="flex w-full items-center">
+    <label for="colorId" class="w-40">{{ t(props.thematicName) }}</label>
+    <div class="grow">
+      <input
+        v-if="color"
+        id="colorId"
+        type="color"
+        class="w-11 h-5 py-[1px] px-[2px]"
+        :value="props.color"
+      />
+    </div>
+    <input
+      type="checkbox"
+      class="flex-none mr-3"
+      :aria-label="
+        t('Show or hide {{ thematicName }}', {
+          thematicName: props.thematicName,
+        })
+      "
+    />
+  </div>
+</template>

--- a/src/components/style-selector/medium-style-item.vue
+++ b/src/components/style-selector/medium-style-item.vue
@@ -7,6 +7,22 @@ const props = defineProps<{
   style: StyleItem
   colorEditable: boolean
 }>()
+const emit = defineEmits<{
+  (e: 'changeStyle', style: StyleItem): void
+}>()
+
+function updateColor(colorChangeEvent: Event) {
+  const newStyle = Object.assign(Object.assign({}, props.style), {
+    color: colorChangeEvent.target.value,
+  })
+  emit('changeStyle', newStyle)
+}
+function updateVisibility(visibilityChangeEvent: Event) {
+  const newStyle = Object.assign(Object.assign({}, props.style), {
+    visible: visibilityChangeEvent.target.checked,
+  })
+  emit('changeStyle', newStyle)
+}
 </script>
 
 <template>
@@ -19,15 +35,17 @@ const props = defineProps<{
         type="color"
         class="w-11 h-5 py-[1px] px-[2px]"
         :value="props.style.color"
+        @input="updateColor"
       />
     </div>
     <input
       type="checkbox"
       class="flex-none mr-3"
       :checked="props.style.visible"
+      @change="updateVisibility"
       :aria-label="
         t('Show or hide {{ thematicName }}', {
-          thematicName: props.thematicName,
+          thematicName: props.style.label,
         })
       "
     />

--- a/src/components/style-selector/medium-style-item.vue
+++ b/src/components/style-selector/medium-style-item.vue
@@ -12,15 +12,17 @@ const emit = defineEmits<{
 }>()
 
 function updateColor(colorChangeEvent: Event) {
-  const newStyle = Object.assign(Object.assign({}, props.style), {
+  const newStyle = {
+    ...props.style,
     color: colorChangeEvent.target.value,
-  })
+  }
   emit('changeStyle', newStyle)
 }
 function updateVisibility(visibilityChangeEvent: Event) {
-  const newStyle = Object.assign(Object.assign({}, props.style), {
+  const newStyle = {
+    ...props.style,
     visible: visibilityChangeEvent.target.checked,
-  })
+  }
   emit('changeStyle', newStyle)
 }
 </script>

--- a/src/components/style-selector/medium-style-item.vue
+++ b/src/components/style-selector/medium-style-item.vue
@@ -12,18 +12,22 @@ const emit = defineEmits<{
 }>()
 
 function updateColor(colorChangeEvent: Event) {
-  const newStyle = {
-    ...props.style,
-    color: colorChangeEvent.target.value,
+  if (colorChangeEvent.target) {
+    const newStyle = {
+      ...props.style,
+      color: (colorChangeEvent.target as HTMLInputElement).value,
+    }
+    emit('changeStyle', newStyle)
   }
-  emit('changeStyle', newStyle)
 }
 function updateVisibility(visibilityChangeEvent: Event) {
-  const newStyle = {
-    ...props.style,
-    visible: visibilityChangeEvent.target.checked,
+  if (visibilityChangeEvent) {
+    const newStyle = {
+      ...props.style,
+      visible: (visibilityChangeEvent.target as HTMLInputElement).checked,
+    }
+    emit('changeStyle', newStyle)
   }
-  emit('changeStyle', newStyle)
 }
 </script>
 

--- a/src/components/style-selector/medium-style-selector.vue
+++ b/src/components/style-selector/medium-style-selector.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed } from 'vue'
+
+import { getDefaultMediumStyling } from '@/services/styles/styles.service'
+import MediumStyleItem from './medium-style-item.vue'
+import { Layer } from '@/stores/map.store.model'
+
+const { t } = useTranslation()
+const props = defineProps<{
+  layer: Layer
+}>()
+const styles = getDefaultMediumStyling(props.layer.name)
+const isColorVisible = computed(
+  () => props.layer.name === 'basemap_2015_global'
+)
+</script>
+
+<template>
+  <div class="text-white border-2 p-[10px] m-[10px]">
+    <h5 class="text-center mb-3">
+      {{
+        isColorVisible
+          ? t('Select a colour for every theme')
+          : t('Activate categories')
+      }}
+    </h5>
+    <medium-style-item
+      v-for="item in styles"
+      :key="item.unlocalized_label"
+      :color="item.color"
+      :thematicName="item.unlocalized_label"
+    />
+  </div>
+</template>

--- a/src/components/style-selector/medium-style-selector.vue
+++ b/src/components/style-selector/medium-style-selector.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from 'pinia'
 
 import { getDefaultMediumStyling } from '@/services/styles/styles.service'
 import MediumStyleItem from './medium-style-item.vue'
+import { StyleItem } from '@/composables/mvt-styles/mvt-styles.model'
 import { Layer } from '@/stores/map.store.model'
 import { useStyleStore } from '@/stores/style.store'
 
@@ -21,6 +22,12 @@ const isColorVisible = computed(
 const styles = computed(
   () => bgStyle.value || getDefaultMediumStyling(props.layer.name)
 )
+
+function changeStyle(i: number, newStyle: StyleItem) {
+  bgStyle.value = styles.value.map((item, index) =>
+    index === i ? newStyle : item
+  )
+}
 </script>
 
 <template>
@@ -33,9 +40,10 @@ const styles = computed(
       }}
     </h5>
     <medium-style-item
-      v-for="item in styles"
+      v-for="(item, i) in styles"
       :key="item.label"
       :style="item"
+      @changeStyle="changeStyle(i, $event)"
       :colorEditable="isColorVisible"
     />
   </div>

--- a/src/components/style-selector/medium-style-selector.vue
+++ b/src/components/style-selector/medium-style-selector.vue
@@ -9,6 +9,8 @@ import { StyleItem } from '@/composables/mvt-styles/mvt-styles.model'
 import { Layer } from '@/stores/map.store.model'
 import { useStyleStore } from '@/stores/style.store'
 
+const COLOR_EDITABLE_LAYERS = ['basemap_2015_global']
+
 const styleStore = useStyleStore()
 const { bgStyle } = storeToRefs(styleStore)
 
@@ -16,8 +18,8 @@ const { t } = useTranslation()
 const props = defineProps<{
   layer: Layer
 }>()
-const isColorVisible = computed(
-  () => props.layer.name === 'basemap_2015_global'
+const isColorVisible = computed(() =>
+  COLOR_EDITABLE_LAYERS.includes(props.layer.name)
 )
 const styles = computed(
   () => bgStyle.value || getDefaultMediumStyling(props.layer.name)

--- a/src/components/style-selector/medium-style-selector.vue
+++ b/src/components/style-selector/medium-style-selector.vue
@@ -1,18 +1,25 @@
 <script setup lang="ts">
 import { useTranslation } from 'i18next-vue'
 import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
 
 import { getDefaultMediumStyling } from '@/services/styles/styles.service'
 import MediumStyleItem from './medium-style-item.vue'
 import { Layer } from '@/stores/map.store.model'
+import { useStyleStore } from '@/stores/style.store'
+
+const styleStore = useStyleStore()
+const { bgStyle } = storeToRefs(styleStore)
 
 const { t } = useTranslation()
 const props = defineProps<{
   layer: Layer
 }>()
-const styles = getDefaultMediumStyling(props.layer.name)
 const isColorVisible = computed(
   () => props.layer.name === 'basemap_2015_global'
+)
+const styles = computed(
+  () => bgStyle.value || getDefaultMediumStyling(props.layer.name)
 )
 </script>
 
@@ -27,9 +34,9 @@ const isColorVisible = computed(
     </h5>
     <medium-style-item
       v-for="item in styles"
-      :key="item.unlocalized_label"
-      :color="item.color"
-      :thematicName="item.unlocalized_label"
+      :key="item.label"
+      :style="item"
+      :colorEditable="isColorVisible"
     />
   </div>
 </template>

--- a/src/components/style-selector/simple-style-selector.spec.ts
+++ b/src/components/style-selector/simple-style-selector.spec.ts
@@ -57,8 +57,7 @@ describe('StyleEditor', () => {
       expect(styleStore.bgStyle[0].label).toBe('Roads primary')
       expect(styleStore.bgStyle[0].color).toBe('#f7f7f7')
     }
-    expect(wrapper.findAll('button').length).toBe(7)
-    expect(wrapper.findAll('button')[6].element.textContent).toBe('Reset style')
+    expect(wrapper.findAll('button').length).toBe(6)
     await wrapper.vm.onStylingSelected(dummySimpleStyles[0])
     if (styleStore.bgStyle) {
       expect(styleStore.bgStyle[0].label).toBe('Roads primary')

--- a/src/components/style-selector/simple-style-selector.vue
+++ b/src/components/style-selector/simple-style-selector.vue
@@ -36,9 +36,6 @@ watch(
 function onStylingSelected(item: SimpleStyle) {
   styleStore.setSimpleStyle(item)
 }
-function resetStyle() {
-  styleStore.setStyle(null)
-}
 </script>
 
 <template>
@@ -78,8 +75,5 @@ function resetStyle() {
         </span>
       </button>
     </div>
-    <button @click="resetStyle" class="lux-btn">
-      {{ t('Reset style', { ns: 'client' }) }}
-    </button>
   </div>
 </template>

--- a/src/components/style-selector/simple-style-selector.vue
+++ b/src/components/style-selector/simple-style-selector.vue
@@ -13,7 +13,8 @@ const { t } = useTranslation()
 const styleStore = useStyleStore()
 const styleService = useMvtStyles()
 const { bgStyle } = storeToRefs(styleStore)
-const simpleStyles = ref(bgConfigFixture().simple_styles.road)
+const simpleStyleConf = bgConfigFixture().simple_styles.road
+const simpleStyles = ref(simpleStyleConf)
 
 const props = defineProps({
   isOpen: {
@@ -21,7 +22,6 @@ const props = defineProps({
     default: true,
   },
 })
-const simpleStyleConf = bgConfigFixture().simple_styles.road
 // does not seem to work with "computed" => therefore using "watch"
 watch(
   bgStyle,

--- a/src/components/style-selector/simple-style-selector.vue
+++ b/src/components/style-selector/simple-style-selector.vue
@@ -29,7 +29,8 @@ watch(
     (simpleStyles.value = styleService.checkSelection(
       newBgStyle || [],
       simpleStyleConf
-    ))
+    )),
+  { immediate: true }
 )
 
 function onStylingSelected(item: SimpleStyle) {

--- a/src/components/style-selector/simple-style-selector.vue
+++ b/src/components/style-selector/simple-style-selector.vue
@@ -3,10 +3,9 @@ import { useTranslation } from 'i18next-vue'
 import { ref, watch } from 'vue'
 
 import { useStyleStore } from '@/stores/style.store'
-import { statePersistorStyleService } from '@/services/state-persistor/state-persistor-bgstyle.service'
 import SimpleStyleItem from './simple-style-item.vue'
 import { bgConfigFixture } from '@/__fixtures__/background.config.fixture'
-import { SimpleRoadStyle } from '@/composables/mvt-styles/mvt-styles.model'
+import { SimpleStyle } from '@/composables/mvt-styles/mvt-styles.model'
 import { storeToRefs } from 'pinia'
 import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
 
@@ -14,9 +13,7 @@ const { t } = useTranslation()
 const styleStore = useStyleStore()
 const styleService = useMvtStyles()
 const { bgStyle } = storeToRefs(styleStore)
-const simpleStyles = ref(bgConfigFixture().simple_styles)
-
-statePersistorStyleService.bootstrapStyle()
+const simpleStyles = ref(bgConfigFixture().simple_styles.road)
 
 const props = defineProps({
   isOpen: {
@@ -24,7 +21,7 @@ const props = defineProps({
     default: true,
   },
 })
-const simpleStyleConf = bgConfigFixture().simple_styles
+const simpleStyleConf = bgConfigFixture().simple_styles.road
 // does not seem to work with "computed" => therefore using "watch"
 watch(
   bgStyle,
@@ -35,11 +32,11 @@ watch(
     ))
 )
 
-function onStylingSelected(item: SimpleRoadStyle) {
+function onStylingSelected(item: SimpleStyle) {
   styleStore.setSimpleStyle(item)
 }
 function resetStyle() {
-  styleStore.setSimpleStyle(null)
+  styleStore.setStyle(null)
 }
 </script>
 

--- a/src/components/style-selector/style-selector.vue
+++ b/src/components/style-selector/style-selector.vue
@@ -23,7 +23,7 @@ const styleCapabilities = computed(() =>
 
 watch(bgLayer, bgLayer => {
   if (!styles.isLayerStyleEditable(bgLayer)) {
-    appStore.toggleStyleEditorPanel(false)
+    appStore.closeStyleEditorPanel()
   }
 })
 
@@ -38,9 +38,7 @@ function resetStyle() {
 
 <template>
   <div v-if="styleCapabilities.isEditable">
-    <button @click="() => appStore.toggleStyleEditorPanel(false)">
-      X close
-    </button>
+    <button @click="() => appStore.closeStyleEditorPanel()">X close</button>
     <h2 class="h-20 shrink-0 flex justify-between lux-panel-title">
       {{ t('Style editor') }}
     </h2>

--- a/src/components/style-selector/style-selector.vue
+++ b/src/components/style-selector/style-selector.vue
@@ -7,11 +7,13 @@ import SimpleStyleSelector from '@/components/style-selector/simple-style-select
 import MediumStyleSelector from '@/components/style-selector/medium-style-selector.vue'
 import { useAppStore } from '@/stores/app.store'
 import { useMapStore } from '@/stores/map.store'
+import { useStyleStore } from '@/stores/style.store'
 import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
 
 const { t } = useTranslation()
 const mapStore = useMapStore()
 const appStore = useAppStore()
+const styleStore = useStyleStore()
 const { bgLayer } = storeToRefs(mapStore)
 const styles = useMvtStyles()
 
@@ -28,6 +30,10 @@ watch(bgLayer, bgLayer => {
 let isSimpleStyleOpen = ref(false)
 let isMediumStyleOpen = ref(false)
 let isAdvancedStyleOpen = ref(false)
+
+function resetStyle() {
+  styleStore.setStyle(null)
+}
 </script>
 
 <template>
@@ -62,5 +68,8 @@ let isAdvancedStyleOpen = ref(false)
       </button>
       <!-- Advanced style editor here -->
     </div>
+    <button @click="resetStyle" class="lux-btn">
+      {{ t('Reset style', { ns: 'client' }) }}
+    </button>
   </div>
 </template>

--- a/src/components/style-selector/style-selector.vue
+++ b/src/components/style-selector/style-selector.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useTranslation } from 'i18next-vue'
+
+import SimpleStyleSelector from '@/components/style-selector/simple-style-selector.vue'
+import MediumStyleSelector from '@/components/style-selector/medium-style-selector.vue'
+import { useAppStore } from '@/stores/app.store'
+import { useMapStore } from '@/stores/map.store'
+
+const { t } = useTranslation()
+const mapStore = useMapStore()
+const appStore = useAppStore()
+const { bgLayer } = storeToRefs(mapStore)
+
+let isSimpleStyleOpen = ref(false)
+let isMediumStyleOpen = ref(false)
+let isAdvancedStyleOpen = ref(false)
+</script>
+
+<template>
+  <div>
+    <button @click="() => appStore.toggleStyleEditorPanel()">X close</button>
+    <h2 class="h-20 shrink-0 flex justify-between lux-panel-title">
+      {{ t('Style editor') }}
+    </h2>
+    <div>
+      <button @click="() => (isSimpleStyleOpen = !isSimpleStyleOpen)">
+        {{ t('Choose a predefined style') }}
+      </button>
+      <simple-style-selector :class="isSimpleStyleOpen ? '' : 'hidden'" />
+    </div>
+
+    <div>
+      <button @click="() => (isMediumStyleOpen = !isMediumStyleOpen)">
+        {{ t('Change main colours') }}
+      </button>
+      <medium-style-selector
+        :class="isMediumStyleOpen ? '' : 'hidden'"
+        v-if="bgLayer"
+        :layer="bgLayer"
+      />
+    </div>
+
+    <div>
+      <button @click="() => (isAdvancedStyleOpen = !isAdvancedStyleOpen)">
+        {{ t('Advanced settings') }}
+      </button>
+      <!-- Advanced style editor here -->
+    </div>
+  </div>
+</template>

--- a/src/composables/map/ol.synchronizer.ts
+++ b/src/composables/map/ol.synchronizer.ts
@@ -75,7 +75,7 @@ export class OlSynchronizer {
         openLayers.applyOnBgLayer(map, bgLayer =>
           styleService.applyStyle(
             bgLayer,
-            newStyle || getDefaultMediumStyling(bgLayer)
+            newStyle || getDefaultMediumStyling(bgLayer.get('label'))
           )
         )
     )

--- a/src/composables/map/ol.synchronizer.ts
+++ b/src/composables/map/ol.synchronizer.ts
@@ -8,6 +8,7 @@ import { useStyleStore } from '@/stores/style.store'
 import useMap from './map.composable'
 import { VectorSourceDict } from '@/composables/mvt-styles/mvt-styles.model'
 import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
+import { getDefaultMediumStyling } from '@/services/styles/styles.service'
 
 export class OlSynchronizer {
   previousLayers: Layer[]
@@ -72,7 +73,10 @@ export class OlSynchronizer {
       () => styleStore.bgStyle,
       newStyle =>
         openLayers.applyOnBgLayer(map, bgLayer =>
-          styleService.applyStyle(bgLayer, newStyle || [])
+          styleService.applyStyle(
+            bgLayer,
+            newStyle || getDefaultMediumStyling(bgLayer)
+          )
         )
     )
 

--- a/src/composables/mvt-styles/mvt-styles.composable.ts
+++ b/src/composables/mvt-styles/mvt-styles.composable.ts
@@ -187,6 +187,9 @@ export default function useMvtStyles() {
             'lu_landcover_wood',
             'lu_landcover_grass',
             'lu_waterway_tunnel',
+            'lu_landuse_gras',
+            'lu_landuse_wood',
+            'landcover_grass',
           ].indexOf(prop) !== -1
         ) {
           return

--- a/src/composables/mvt-styles/mvt-styles.composable.ts
+++ b/src/composables/mvt-styles/mvt-styles.composable.ts
@@ -1,8 +1,11 @@
 import {
-  SimpleRoadStyle,
+  SimpleStyle,
   StyleItem,
   stylePropertyTypeList,
+  StyleCapabilities,
+  BgLayerDef,
 } from '@/composables/mvt-styles/mvt-styles.model'
+import type { Layer } from '@/stores/map.store.model'
 import { bgConfigFixture } from '@/__fixtures__/background.config.fixture'
 import BaseLayer from 'ol/layer/Base'
 import { Map as MaplibreMap } from 'maplibre-gl'
@@ -137,7 +140,7 @@ export default function useMvtStyles() {
   }
 
   function getRoadStyleFromSimpleStyle(
-    simpleStyle: SimpleRoadStyle | null
+    simpleStyle: SimpleStyle | null
   ): StyleItem[] {
     const med_road_style = bgConfigFixture().medium_default_styles
       .road as StyleItem[]
@@ -201,11 +204,32 @@ export default function useMvtStyles() {
     }
   }
 
+  function isLayerStyleEditable(bgLayer: Layer | undefined | null): boolean {
+    const bgLayerDef: BgLayerDef | undefined = bgConfigFixture().bg_layers.find(
+      l => l.id == bgLayer?.id
+    )
+    return bgLayerDef?.vector_id !== undefined
+  }
+
+  function getStyleCapabilitiesFromLayer(
+    bgLayer: Layer | undefined | null
+  ): StyleCapabilities {
+    const bgLayerDef: BgLayerDef | undefined = bgConfigFixture().bg_layers.find(
+      l => l.id == bgLayer?.id
+    )
+    return {
+      isEditable: bgLayerDef?.vector_id !== undefined,
+      hasSimpleStyle: bgLayerDef?.simple_style_class !== undefined,
+      hasAdvancedStyle: bgLayerDef?.medium_style_class !== undefined,
+      hasExpertStyle: bgLayerDef?.expert_style_class !== undefined,
+    }
+  }
+
   function checkSelection(
     bgStyle: StyleItem[],
-    simpleStyleConf: SimpleRoadStyle[]
+    simpleStyleConf: SimpleStyle[]
   ) {
-    return simpleStyleConf.map((style: SimpleRoadStyle) =>
+    return simpleStyleConf.map((style: SimpleStyle) =>
       Object.assign(style, {
         selected: style.colors.every(
           (element, i) => bgStyle[i]?.color === element
@@ -219,5 +243,7 @@ export default function useMvtStyles() {
     getRoadStyleFromSimpleStyle,
     applyStyle,
     checkSelection,
+    isLayerStyleEditable,
+    getStyleCapabilitiesFromLayer,
   }
 }

--- a/src/composables/mvt-styles/mvt-styles.model.ts
+++ b/src/composables/mvt-styles/mvt-styles.model.ts
@@ -1,5 +1,14 @@
 import { LayerId } from '@/stores/map.store.model'
 
+export interface BgLayerDef {
+  icon_id: string
+  vector_id?: string
+  simple_style_class?: string
+  medium_style_class?: string
+  expert_style_class?: string
+  id: number
+  is_default?: boolean
+}
 export interface IMvtConfig {
   label: string
   defaultMapBoxStyle: string
@@ -10,7 +19,14 @@ export interface IMvtConfig {
 }
 export type VectorSourceDict = Map<LayerId, IMvtConfig>
 
-export interface SimpleRoadStyle {
+export interface StyleCapabilities {
+  isEditable: boolean
+  hasSimpleStyle: boolean
+  hasAdvancedStyle: boolean
+  hasExpertStyle: boolean
+}
+
+export interface SimpleStyle {
   unlocalized_label: string
   hillshade: boolean
   colors: string[]

--- a/src/services/state-persistor/state-persistor-bgstyle.service.ts
+++ b/src/services/state-persistor/state-persistor-bgstyle.service.ts
@@ -17,7 +17,7 @@ class StatePersistorStyleService {
     // eslint-disable-next-line prefer-const
     stop = watchEffect(() => {
       if (styleStore.bgVectorSources) {
-        this.restoreStyle()
+        this.restoreStyle(false)
         if (activatePersistance) this.persistStyle()
         activatePersistance = true
         stop && stop() // test if exists, for HMR support

--- a/src/services/state-persistor/state-persistor-bgstyle.service.ts
+++ b/src/services/state-persistor/state-persistor-bgstyle.service.ts
@@ -17,7 +17,7 @@ class StatePersistorStyleService {
     // eslint-disable-next-line prefer-const
     stop = watchEffect(() => {
       if (styleStore.bgVectorSources) {
-        this.restoreStyle(false)
+        this.restoreStyle()
         if (activatePersistance) this.persistStyle()
         activatePersistance = true
         stop && stop() // test if exists, for HMR support

--- a/src/services/state-persistor/state-persistor-bgstyle.service.ts
+++ b/src/services/state-persistor/state-persistor-bgstyle.service.ts
@@ -55,17 +55,10 @@ class StatePersistorStyleService {
   }
 
   restoreStyle() {
-    console.log('restoring style')
     const styleStore = useStyleStore()
-    /*const bgLayer = storageHelper.getValue(
-        SP_KEY_BGLAYER,
-        storageLayerMapper.bgLayerIdToBgLayer
-    )*/
-    //const styleStore = useStyleStore()
+    styleStore.setStyle(null)
     const mapStore = useMapStore()
-    // const { bgLayer } = storeToRefs(mapStore)
     const bgLayer = mapStore.bgLayer
-    console.log(`restoring bg style ${bgLayer?.name}`)
     if (bgLayer) {
       let bgStyle = storageHelper.getValue(
         SP_KEY_SERIAL,

--- a/src/services/styles/styles.model.ts
+++ b/src/services/styles/styles.model.ts
@@ -1,0 +1,10 @@
+export interface MediumStyle {
+  unlocalized_label: string
+  color?: string
+  styleProperties?: {
+    type: string
+    properties: string[]
+  }[]
+  opacity?: string
+  visible?: boolean
+}

--- a/src/services/styles/styles.model.ts
+++ b/src/services/styles/styles.model.ts
@@ -1,5 +1,5 @@
 export interface MediumStyle {
-  unlocalized_label: string
+  label: string
   color?: string
   styleProperties?: {
     type: string

--- a/src/services/styles/styles.service.ts
+++ b/src/services/styles/styles.service.ts
@@ -1,0 +1,17 @@
+import { bgConfigFixture } from '../../__fixtures__/background.config.fixture'
+import { MediumStyle } from './styles.model'
+
+export function getDefaultMediumStyling(label: string): MediumStyle[] {
+  if (label === 'topogr_global' || label === 'topo_bw_jpeg')
+    return getDefaultMediumTopoStyling()
+
+  return getDefaultMediumRoadmapStyling() // Default value at init app loading
+}
+
+export function getDefaultMediumRoadmapStyling() {
+  return bgConfigFixture().medium_default_styles.road
+}
+
+export function getDefaultMediumTopoStyling() {
+  return bgConfigFixture().medium_default_styles.topo
+}

--- a/src/services/styles/styles.service.ts
+++ b/src/services/styles/styles.service.ts
@@ -1,5 +1,5 @@
 import { bgConfigFixture } from '../../__fixtures__/background.config.fixture'
-import { MediumStyle } from './styles.model'
+import { StyleItem as MediumStyle } from '@/composables/mvt-styles/mvt-styles.model'
 
 export function getDefaultMediumStyling(label: string): MediumStyle[] {
   if (label === 'topogr_global' || label === 'topo_bw_jpeg')
@@ -8,10 +8,10 @@ export function getDefaultMediumStyling(label: string): MediumStyle[] {
   return getDefaultMediumRoadmapStyling() // Default value at init app loading
 }
 
-export function getDefaultMediumRoadmapStyling() {
-  return bgConfigFixture().medium_default_styles.road
+export function getDefaultMediumRoadmapStyling(): MediumStyle[] {
+  return bgConfigFixture().medium_default_styles.road as MediumStyle[]
 }
 
-export function getDefaultMediumTopoStyling() {
-  return bgConfigFixture().medium_default_styles.topo
+export function getDefaultMediumTopoStyling(): MediumStyle[] {
+  return bgConfigFixture().medium_default_styles.topo as MediumStyle[]
 }

--- a/src/stores/app.store.ts
+++ b/src/stores/app.store.ts
@@ -16,9 +16,12 @@ export const useAppStore = defineStore(
       layersOpen.value = open
     }
 
-    function toggleStyleEditorPanel(force?: boolean) {
-      styleEditorOpen.value =
-        force !== undefined ? force : !styleEditorOpen.value
+    function toggleStyleEditorPanel() {
+      styleEditorOpen.value = !styleEditorOpen.value
+    }
+
+    function closeStyleEditorPanel() {
+      styleEditorOpen.value = false
     }
 
     return {
@@ -28,6 +31,7 @@ export const useAppStore = defineStore(
       setLang,
       setLayersOpen,
       toggleStyleEditorPanel,
+      closeStyleEditorPanel,
     }
   },
   {}

--- a/src/stores/app.store.ts
+++ b/src/stores/app.store.ts
@@ -6,14 +6,29 @@ export const useAppStore = defineStore(
   () => {
     const lang = ref('fr')
     const layersOpen = ref()
+    const styleEditorOpen = ref(false)
+
     function setLang(language: string) {
       lang.value = language
     }
+
     function setLayersOpen(open: boolean) {
       layersOpen.value = open
     }
 
-    return { lang, layersOpen, setLang, setLayersOpen }
+    function toggleStyleEditorPanel(force?: boolean) {
+      styleEditorOpen.value =
+        force !== undefined ? force : !styleEditorOpen.value
+    }
+
+    return {
+      lang,
+      layersOpen,
+      styleEditorOpen,
+      setLang,
+      setLayersOpen,
+      toggleStyleEditorPanel,
+    }
   },
   {}
 )

--- a/src/stores/style.store.ts
+++ b/src/stores/style.store.ts
@@ -4,7 +4,7 @@ import { shallowRef, ShallowRef } from 'vue'
 import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
 import {
   IMvtConfig,
-  SimpleRoadStyle,
+  SimpleStyle,
   StyleItem,
   VectorSourceDict,
 } from '@/composables/mvt-styles/mvt-styles.model'
@@ -14,7 +14,7 @@ export const useStyleStore = defineStore(
   'style',
   () => {
     const styleService = useMvtStyles()
-    const bgStyle: ShallowRef<StyleItem[] | undefined> = shallowRef()
+    const bgStyle: ShallowRef<StyleItem[] | undefined | null> = shallowRef()
     const bgVectorSources: ShallowRef<VectorSourceDict> = shallowRef(new Map())
 
     const promises: Promise<{ id: string; config: IMvtConfig }>[] = []
@@ -37,11 +37,11 @@ export const useStyleStore = defineStore(
       bgVectorSources.value = vectorDict
     })
 
-    function setSimpleStyle(simpleStyle: SimpleRoadStyle | null) {
+    function setSimpleStyle(simpleStyle: SimpleStyle | null) {
       bgStyle.value = styleService.getRoadStyleFromSimpleStyle(simpleStyle)
     }
 
-    function setStyle(style: StyleItem[]) {
+    function setStyle(style: StyleItem[] | null) {
       bgStyle.value = style
     }
 

--- a/src/stores/style.store.ts
+++ b/src/stores/style.store.ts
@@ -17,7 +17,7 @@ export const useStyleStore = defineStore(
     const bgStyle: ShallowRef<StyleItem[] | undefined | null> = shallowRef()
     const bgVectorSources: ShallowRef<VectorSourceDict> = shallowRef(new Map())
 
-    const promises: Promise<{ id: string; config: IMvtConfig }>[] = []
+    const promises: Promise<{ id: LayerId; config: IMvtConfig }>[] = []
     bgConfigFixture().bg_layers.forEach(bgLayer => {
       if (bgLayer.vector_id) {
         const conf = styleService.setConfigForLayer(

--- a/src/stores/style.store.ts
+++ b/src/stores/style.store.ts
@@ -2,6 +2,7 @@ import { acceptHMRUpdate, defineStore } from 'pinia'
 import { shallowRef, ShallowRef } from 'vue'
 
 import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
+import type { LayerId } from '@/stores/map.store.model'
 import {
   IMvtConfig,
   SimpleStyle,


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-592

### Description

simple and medium style editors and reset are connected to the style store

there is a difference to prod, since the style is different if loaded without custom style or reset to custom style. This is due to the fact that the styles apparently have diverged and the custom default style is no longer identical to the online default style. This difference can be seen in the screenshots below.
This glitch shall be fixed once the clients have checked the style.

### Screenshots

default style:
![image](https://user-images.githubusercontent.com/61978301/228003522-b72890b3-b197-4fa4-95df-fd770e00a0cb.png)

default style after reset:
![image](https://user-images.githubusercontent.com/61978301/228003651-14b320d4-1773-47f3-a718-e472f89b220e.png)

custom style:
![image](https://user-images.githubusercontent.com/61978301/228003986-c223cb83-8a2c-4e00-bb18-82c76d746b44.png)
