### PR TITLE
GSLUX-635: Add workflow step to build and tag lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,19 @@ jobs:
           cache: 'npm'
       - run: npm ci
 
+      - name: Build library and increment version tag (only on merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          npm run build:lib:prod
+          npm version patch
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "chore(lib): npm run build:lib:prod"
+          git push
+          git push --tags
+
       - name: Get branch name (merge)
         if: github.event_name != 'pull_request'
         shell: bash


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-635

### Description

PR should build lib, increment version in package.json and create a tag with corresponding version, when merging PRs on main.

When testing on the `pull_request` event, I had the [error](https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/actions/runs/5575820967/jobs/10186249989#step:6:24) "nothing to commit" because of a detached HEAD. Not sure if there will be the same issue when merging on main.
