### PR TITLE
GSLUX-622 (Fix): Make backend urls relative for lib

### DIFF
--- a/bundle/lux.dist.mjs
+++ b/bundle/lux.dist.mjs
@@ -45889,9 +45889,9 @@ function useMvtStyles() {
     }
     return baseStyle;
   }
-  const getvtstyleUrl_ = "http://localhost:8080/getvtstyle";
-  const uploadvtstyleUrl_ = "http://localhost:8080/uploadvtstyle";
-  const deletevtstyleUrl_ = "http://localhost:8080/deletevtstyle";
+  const getvtstyleUrl_ = "/getvtstyle";
+  const uploadvtstyleUrl_ = "/uploadvtstyle";
+  const deletevtstyleUrl_ = "/deletevtstyle";
   function unregisterStyle(styleId) {
     if (styleId === null) {
       return Promise.resolve();

--- a/bundle/lux.dist.umd.js
+++ b/bundle/lux.dist.umd.js
@@ -45893,9 +45893,9 @@ uniform ${i3} ${o3} u_${a3};
       }
       return baseStyle;
     }
-    const getvtstyleUrl_ = "http://localhost:8080/getvtstyle";
-    const uploadvtstyleUrl_ = "http://localhost:8080/uploadvtstyle";
-    const deletevtstyleUrl_ = "http://localhost:8080/deletevtstyle";
+    const getvtstyleUrl_ = "/getvtstyle";
+    const uploadvtstyleUrl_ = "/uploadvtstyle";
+    const deletevtstyleUrl_ = "/deletevtstyle";
     function unregisterStyle(styleId) {
       if (styleId === null) {
         return Promise.resolve();

--- a/src/composables/mvt-styles/mvt-styles.composable.ts
+++ b/src/composables/mvt-styles/mvt-styles.composable.ts
@@ -199,9 +199,9 @@ export default function useMvtStyles() {
     return baseStyle
   }
 
-  const getvtstyleUrl_ = 'http://localhost:8080/getvtstyle'
-  const uploadvtstyleUrl_ = 'http://localhost:8080/uploadvtstyle'
-  const deletevtstyleUrl_ = 'http://localhost:8080/deletevtstyle'
+  const getvtstyleUrl_ = '/getvtstyle'
+  const uploadvtstyleUrl_ = '/uploadvtstyle'
+  const deletevtstyleUrl_ = '/deletevtstyle'
 
   function unregisterStyle(styleId: String | null) {
     if (styleId === null) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,10 @@ function removeDataTestAttrs(node: RootNode | TemplateChildNode) {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
+  const backendHost = // host and proxy not used by lib that uses relative paths
+    mode == 'production'
+      ? 'https://migration.geoportail.lu/' // used for gh pages
+      : 'http://localhost:8080' // used for local dev
   const base: UserConfig = {
     plugins: [
       vue({
@@ -33,6 +37,13 @@ export default defineConfig(({ command, mode }) => {
     test: {
       globals: true,
       setupFiles: 'vitest.setup.ts',
+    },
+    server: {
+      proxy: {
+        '/getvtstyle': backendHost,
+        '/uploadvtstyle': backendHost,
+        '/deletevtstyle': backendHost,
+      },
     },
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,10 +15,7 @@ function removeDataTestAttrs(node: RootNode | TemplateChildNode) {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
-  const backendHost = // host and proxy not used by lib that uses relative paths
-    mode == 'production'
-      ? 'https://migration.geoportail.lu/' // used for gh pages
-      : 'http://localhost:8080' // used for local dev
+  const backendHost = 'http://localhost:8080' // used for local dev
   const base: UserConfig = {
     plugins: [
       vue({


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-622

### Description

Follow-up PR to #60 to fix following error in v3:

`Access to fetch at 'http://localhost:8080/uploadvtstyle' from origin 'https://migration.geoportail.lu' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`

Makes backend urls used for styles relative for lib to work in v3.

Uses vite proxy to send requests to local backend for dev.

Note : In v3 this PR should currently not have an impact on the functionality, as the legacy style selector is used. It should however prevent the error messages in the console which are triggered by the v4-lib in the background.