### PR TITLE
GSLUX-635: Fix lib build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
         shell: bash
         run: |
           npm run build:lib:prod
-          npm version patch
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
           git commit -m "chore(lib): npm run build:lib:prod"
+          npm version patch
           git push
           git push --tags
 


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-635

### Description

PR should fix building lib in CI by setting git config before `npm version patch`, which actually creates a commit by itself.


