### PR TITLE
GSLUX-569: Time layers permalink (parent GSLUX-594)

### DIFF
--- a/cypress/e2e/layers-selection.cy.ts
+++ b/cypress/e2e/layers-selection.cy.ts
@@ -22,7 +22,7 @@ describe('Catalogue', () => {
 
     it('adds selected layers to the map and to the layer manager', () => {
       cy.get('[data-cy="myLayersButton"]').click()
-      cy.get('[data-cy="myLayers"] > li').should('have.length', 3)
+      cy.get('[data-cy="myLayers"] > ul > li').should('have.length', 2)
     })
 
     it('displays title with updated number of layers', () => {
@@ -40,7 +40,7 @@ describe('Catalogue', () => {
       cy.get('[data-cy="myLayers"]').find('button').eq(2).click()
       cy.get('[data-cy="myLayers"]')
         .find('button')
-        .eq(5)
+        .eq(4)
         .click()
         .should(() => {
           expect(localStorage.getItem('opacities')).to.eq('1-0')
@@ -49,7 +49,7 @@ describe('Catalogue', () => {
       cy.url().should('contains', 'opacities=1-0')
       cy.get('[data-cy="myLayers"]')
         .find('button')
-        .eq(5)
+        .eq(4)
         .should('have.class', 'fa-eye-slash')
     })
   })
@@ -72,7 +72,7 @@ describe('Catalogue', () => {
       })
 
       cy.get('[data-cy="myLayersButton"]').click()
-      cy.get('[data-cy="myLayers"] > li').should('have.length', 3)
+      cy.get('[data-cy="myLayers"] > ul > li').should('have.length', 2)
     })
   })
 })
@@ -104,6 +104,6 @@ describe('Remote layers', () => {
     cy.get(
       '[data-cy="layerLabel-WMS||http://wmts1.geoportail.lu/opendata/service||ortho_2001"]'
     ).click()
-    cy.get('[data-cy="myLayers"] > li').should('have.length', 2)
+    cy.get('[data-cy="myLayers"] > ul > li').should('have.length', 1)
   })
 })

--- a/cypress/e2e/permalink/layers.cy.ts
+++ b/cypress/e2e/permalink/layers.cy.ts
@@ -59,7 +59,33 @@ describe('Permalink/State persistor - Layers', () => {
   })
 
   describe('Save layers to url', () => {
-    describe('When updating layer time with datepicker widget', () => {
+    describe('When updating layer time with datepicker widget with value mode', () => {
+      it('updates the layer time (date start) in the url', () => {
+        cy.visit(
+          '?version=3&lang=fr&layers=1858&opacities=1&time=2014-09-14T00%253A00%253A00Z'
+        )
+        cy.get('[data-cy="myLayersButton"]').click()
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(0)
+          .type('2015-09-02')
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(0)
+          .trigger('change')
+        cy.url().should('contains', '&time=2015-09-02T00%253A00%253A00Z')
+      })
+
+      it('does not have the date end datepicker', () => {
+        cy.visit(
+          '?version=3&lang=fr&layers=1858&opacities=1&time=2014-09-14T00%253A00%253A00Z'
+        )
+        cy.get('[data-cy="myLayersButton"]').click()
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(1)
+          .should('not.exist')
+      })
+    })
+
+    describe('When updating layer time with datepicker widget with range mode', () => {
       it('updates the layer time (date start) in the url', () => {
         cy.visit(
           '/?version=3&lang=fr&layers=1859&time=2014-10-14T00%253A00%253A00Z%252F2020-12-31T00%253A00%253A00Z'
@@ -95,7 +121,7 @@ describe('Permalink/State persistor - Layers', () => {
       })
     })
 
-    describe('When updating layer time with slider widget', () => {
+    describe('When updating layer time with slider widget with value mode', () => {
       it('updates the layer time (date start) in the url', () => {
         cy.visit(
           '/?version=3&lang=fr&layers=1860&time=2019-01-01T00%253A00%253A00Z%252F'
@@ -105,7 +131,7 @@ describe('Permalink/State persistor - Layers', () => {
         cy.get('[data-cy="myLayers"] input.lux-time-slidebar')
           .eq(0)
           .trigger('change')
-        cy.url().should('contains', '&time=2022-08-01T00%253A00%253A00Z%252F')
+        cy.url().should('contains', '&time=2022-08-01T00%253A00%253A00Z')
       })
     })
   })

--- a/cypress/e2e/permalink/layers.cy.ts
+++ b/cypress/e2e/permalink/layers.cy.ts
@@ -1,7 +1,7 @@
 describe('Permalink/State persistor - Layers', () => {
   describe('Restore layers from url', () => {
     describe('When layer opacities have values', () => {
-      it('updates the url with the right opacity', () => {
+      it('updates the input opacity with the right opacity', () => {
         cy.visit(
           '/?lang=lb&X=762744&Y=6414661&version=3&zoom=11&layers=346-354-269&opacities=0.5-1-0.7&bgLayer=orthogr_2013_global'
         )
@@ -30,6 +30,82 @@ describe('Permalink/State persistor - Layers', () => {
           .each($el => {
             cy.wrap($el).should('have.value', '100')
           })
+      })
+    })
+
+    describe('When layer times param have values', () => {
+      it('updates the layer items in the layer manager with the dates', () => {
+        cy.visit(
+          '/?version=3&layers=1860-1858-1859&opacities=1-1-1&time=2019-08-01T00%253A00%253A00Z%252F--2014-08-31T12%253A43%253A47Z%252F2020-12-31T23%253A59%253A59Z--2014-10-14T00%253A00%253A00Z%252F2020-12-31T00%253A00%253A00Z'
+        )
+        cy.get('[data-cy="myLayersButton"]').click()
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(0)
+          .should('have.value', '2014-10-14')
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(1)
+          .should('have.value', '2020-12-31')
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(2)
+          .should('have.value', '2014-08-31')
+        cy.get('[data-cy="myLayers"] input.lux-time-slidebar')
+          .eq(0)
+          .should('have.value', '9')
+        cy.get('[data-cy="myLayers"] .lux-time-slider-start-date')
+          .eq(0)
+          .should('have.text', '8-2019')
+      })
+    })
+  })
+
+  describe('Save layers to url', () => {
+    describe('When updating layer time with datepicker widget', () => {
+      it('updates the layer time (date start) in the url', () => {
+        cy.visit(
+          '/?version=3&lang=fr&layers=1859&time=2014-10-14T00%253A00%253A00Z%252F2020-12-31T00%253A00%253A00Z'
+        )
+        cy.get('[data-cy="myLayersButton"]').click()
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(0)
+          .type('2014-09-02')
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(0)
+          .trigger('change')
+        cy.url().should(
+          'contains',
+          '&time=2014-09-02T00%253A00%253A00Z%252F2020-12-31T00%253A00%253A00Z'
+        )
+      })
+
+      it('updates the layer time (date end) in the url', () => {
+        cy.visit(
+          '/?version=3&lang=fr&layers=1859&time=2014-10-14T00%253A00%253A00Z%252F2020-12-31T00%253A00%253A00Z'
+        )
+        cy.get('[data-cy="myLayersButton"]').click()
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(1)
+          .type('2020-12-29')
+        cy.get('[data-cy="myLayers"] input.lux-time-datepicker')
+          .eq(1)
+          .trigger('change')
+        cy.url().should(
+          'contains',
+          '&time=2014-10-14T00%253A00%253A00Z%252F2020-12-29T00%253A00%253A00Z'
+        )
+      })
+    })
+
+    describe('When updating layer time with slider widget', () => {
+      it('updates the layer time (date start) in the url', () => {
+        cy.visit(
+          '/?version=3&lang=fr&layers=1860&time=2019-01-01T00%253A00%253A00Z%252F'
+        )
+        cy.get('[data-cy="myLayersButton"]').click()
+        cy.get('[data-cy="myLayers"] input.lux-time-slidebar').eq(0).type('2')
+        cy.get('[data-cy="myLayers"] input.lux-time-slidebar')
+          .eq(0)
+          .trigger('change')
+        cy.url().should('contains', '&time=2022-08-01T00%253A00%253A00Z%252F')
       })
     })
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@camptocamp/ogc-client": "^0.3.4",
         "file-saver": "^2.0.5",
+        "luxon": "^3.4.1",
         "ol": "^6.5.0",
         "pinia": "^2.0.26",
         "sortablejs": "^1.15.0",
@@ -24,6 +25,7 @@
         "@pinia/testing": "^0.0.14",
         "@rushstack/eslint-patch": "^1.1.4",
         "@types/jsdom": "^20.0.1",
+        "@types/luxon": "^3.3.1",
         "@types/node": "^18.11.9",
         "@types/proj4": "^2.5.2",
         "@types/sortablejs": "^1.15.0",
@@ -2858,6 +2860,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.1.tgz",
+      "integrity": "sha512-XOS5nBcgEeP2PpcqJHjCWhUCAzGfXIU8ILOSLpx2FhxqMW9KdxgCGXNOEKGVBfveKtIpztHzKK5vSRVLyW/NqA==",
       "dev": true
     },
     "node_modules/@types/mapbox__point-geometry": {
@@ -9637,6 +9645,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.1.tgz",
+      "integrity": "sha512-2USspxOCXWGIKHwuQ9XElxPPYrDOJHDQ5DQ870CoD+CxJbBnRDIBCfhioUJJjct7BKOy80Ia8cVstIcIMb/0+Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -16248,6 +16264,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.1.tgz",
+      "integrity": "sha512-XOS5nBcgEeP2PpcqJHjCWhUCAzGfXIU8ILOSLpx2FhxqMW9KdxgCGXNOEKGVBfveKtIpztHzKK5vSRVLyW/NqA==",
+      "dev": true
+    },
     "@types/mapbox__point-geometry": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
@@ -21318,6 +21340,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "luxon": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.1.tgz",
+      "integrity": "sha512-2USspxOCXWGIKHwuQ9XElxPPYrDOJHDQ5DQ870CoD+CxJbBnRDIBCfhioUJJjct7BKOy80Ia8cVstIcIMb/0+Q=="
     },
     "magic-string": {
       "version": "0.25.9",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@camptocamp/ogc-client": "^0.3.4",
     "file-saver": "^2.0.5",
+    "luxon": "^3.4.1",
     "ol": "^6.5.0",
     "pinia": "^2.0.26",
     "sortablejs": "^1.15.0",
@@ -42,6 +43,7 @@
     "@pinia/testing": "^0.0.14",
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/jsdom": "^20.0.1",
+    "@types/luxon": "^3.3.1",
     "@types/node": "^18.11.9",
     "@types/proj4": "^2.5.2",
     "@types/sortablejs": "^1.15.0",

--- a/public/assets/locales/client.fr.json
+++ b/public/assets/locales/client.fr.json
@@ -1752,7 +1752,7 @@
   "Click to continue drawing the polygon.": "Cliquez pour continuer le dessin du poligone.",
   "Click to continue drawing<br>Double-click or click last point to finish": "Cliquer pour continuer le dessin<br />Double cliquer ou cliquer sur le dernier point pour finir le dessin",
   "Click to continue drawing<br>Double-click or click starting point to finish": "Cliquer pour continuer le dessin<br />Double cliquer ou cliquer sur le dernier point de départ pour finir le dessin",
-  "Date:": "Date:",
+  "Date:": "Date :",
   "Does not match any criterion": "Ne correspond à aucun critère",
   "Double-click or click last point to finish.": "Double cliquer ou cliquer sur le dernier point pour terminer.",
   "Double-click or click starting point to finish.": "Double cliquer ou cliquer sur le premier point pour terminer.",

--- a/src/__fixtures__/themes.api.fixture.ts
+++ b/src/__fixtures__/themes.api.fixture.ts
@@ -5851,6 +5851,137 @@ export const themesApiFixture = (): ConfigModel => ({
               "mixed": true
             },
             {
+                "id": 1861,
+                "name": "time_layers",
+                "children": [
+                    {
+                        "id": 1857,
+                        "name": "starkregen",
+                        "metadata": {},
+                        "dimensions": {},
+                        "type": "WMS",
+                        "layers": "starkregen",
+                        "imageType": "image/png",
+                        "childLayers": [
+                            {
+                                "name": "starkregen__0"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 1858,
+                        "name": "parz",
+                        "metadata": {
+                            "time_config": "{\"time_override\": {\"timepositions\": [\"2014-08-31T12:43:47.000Z/2020-12-31T23:59:59.000Z/P1M\"]}}"
+                        },
+                        "dimensions": {},
+                        "type": "WMS",
+                        "layers": "parzelle",
+                        "imageType": "image/png",
+                        "childLayers": [
+                            {}
+                        ],
+                        "time": {
+                            "minValue": "2014-08-31T12:43:47Z",
+                            "maxValue": "2020-12-31T23:59:59Z",
+                            "interval": [
+                                0,
+                                1,
+                                0,
+                                0
+                            ],
+                            "resolution": "second",
+                            "minDefValue": "2014-08-31T12:43:47Z",
+                            "maxDefValue": null,
+                            "mode": "value",
+                            "widget": "datepicker"
+                        }
+                    },
+                    {
+                        "id": 1859,
+                        "name": "layer_datepicker_range",
+                        "metadata": {
+                            "time_config": "{\"time_override\": {\"timepositions\": [\"2014-08-31T12:43:47.000Z/2020-12-31T23:59:59.000Z/P1M\"]}}"
+                        },
+                        "dimensions": {},
+                        "type": "WMS",
+                        "layers": "layer_datepicker_range",
+                        "imageType": "image/png",
+                        "childLayers": [
+                            {}
+                        ],
+                        "time": {
+                            "minValue": "2014-08-31T12:43:47Z",
+                            "maxValue": "2020-12-31T23:59:59Z",
+                            "interval": [
+                                0,
+                                1,
+                                0,
+                                0
+                            ],
+                            "resolution": "second",
+                            "minDefValue": "2014-08-31T12:43:47Z",
+                            "maxDefValue": null,
+                            "mode": "range",
+                            "widget": "datepicker"
+                        }
+                    },
+                    {
+                        "id": 1860,
+                        "name": "act_ortho_time",
+                        "metadata": {
+                            "time_config": "{\"default_time\":\"2022-08\",\"time_links\":{\"2001-08\":\"ortho_2001\",\"2004-08\":\"ortho_2004\",\"2007-08\":\"ortho_2007\",\"2010-08\":\"ortho_2010\",\"2013-08\":\"ortho_2013\",\"2016-08\":\"ortho_2016\",\"2017-08\":\"ortho_2017\",\"2018-08\":\"ortho_2018\",\"2019-01\":\"ortho_2019_winter\",\"2019-08\":\"ortho_2019\",\"2020-08\":\"ortho_2020\",\"2021-08\":\"ortho_2021\",\"2022-08\":\"ortho_2022\"}}",
+                            "time_layers": {
+                                "2001-08-01T00:00:00Z": "ortho_2001",
+                                "2004-08-01T00:00:00Z": "ortho_2004",
+                                "2007-08-01T00:00:00Z": "ortho_2007",
+                                "2010-08-01T00:00:00Z": "ortho_2010",
+                                "2013-08-01T00:00:00Z": "ortho_2013",
+                                "2016-08-01T00:00:00Z": "ortho_2016",
+                                "2017-08-01T00:00:00Z": "ortho_2017",
+                                "2018-08-01T00:00:00Z": "ortho_2018",
+                                "2019-01-01T00:00:00Z": "ortho_2019_winter",
+                                "2019-08-01T00:00:00Z": "ortho_2019",
+                                "2020-08-01T00:00:00Z": "ortho_2020",
+                                "2021-08-01T00:00:00Z": "ortho_2021",
+                                "2022-08-01T00:00:00Z": "ortho_2022"
+                            }
+                        },
+                        "dimensions": {},
+                        "type": "WMTS",
+                        "url": "http://wmts.geoportail.lu/mapproxy_4_v3/wmts/1.0.0/WMTSCapabilities.xml",
+                        "layer": "act_ortho_time",
+                        "imageType": "image/jpeg",
+                        "time": {
+                            "minValue": "2001-08-01T00:00:00Z",
+                            "maxValue": "2022-08-01T00:00:00Z",
+                            "values": [
+                                "2001-08-01T00:00:00Z",
+                                "2004-08-01T00:00:00Z",
+                                "2007-08-01T00:00:00Z",
+                                "2010-08-01T00:00:00Z",
+                                "2013-08-01T00:00:00Z",
+                                "2016-08-01T00:00:00Z",
+                                "2017-08-01T00:00:00Z",
+                                "2018-08-01T00:00:00Z",
+                                "2019-01-01T00:00:00Z",
+                                "2019-08-01T00:00:00Z",
+                                "2020-08-01T00:00:00Z",
+                                "2021-08-01T00:00:00Z",
+                                "2022-08-01T00:00:00Z"
+                            ],
+                            "resolution": "month",
+                            "minDefValue": "2022-08-01T00:00:00Z",
+                            "maxDefValue": null,
+                            "mode": "value",
+                            "widget": "slider"
+                        }
+                    }
+                ],
+                "metadata": {},
+                "mixed": true
+            },
+            {
               "id": 484,
               "name": "eau_new_Hydrografie",
               "children": [

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -212,6 +212,14 @@
     border-color: var(--alert-warning-secondary);
     color: var(--alert-warning-tertiary);
   }
+
+  .lux-time-slider input[type='range']::-webkit-slider-thumb {
+    @apply bg-white h-5 w-2 rounded-full border-tertiary;
+    -webkit-appearance: none;
+    box-shadow: 0.1rem 0.1rem 0.1rem rgba(0, 0, 49, 0.2),
+      0 0 0.1rem rgba(0, 0, 75, 0.2);
+    border: 0.1rem solid rgba(0, 0, 30, 0.2);
+  }
 }
 
 .fa-solid {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -225,11 +225,11 @@
     @apply mr-1 min-w-[1.75rem] inline-block;
   }
 
-  .lux-time-slider-datepicker {
+  .lux-time-datepicker {
     @apply border-[#767676] border-[1px] pl-1;
   }
 
-  .lux-time-slider-slidebar {
+  .lux-time-slidebar {
     @apply mt-2 mb-2 ml-0 mr-0 w-full h-1 bg-[#d3e5d7] rounded-sm appearance-none cursor-pointer;
   }
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -220,6 +220,18 @@
       0 0 0.1rem rgba(0, 0, 75, 0.2);
     border: 0.1rem solid rgba(0, 0, 30, 0.2);
   }
+
+  .lux-time-slider-label {
+    @apply mr-1 min-w-[1.75rem] inline-block;
+  }
+
+  .lux-time-slider-datepicker {
+    @apply border-[#767676] border-[1px] pl-1;
+  }
+
+  .lux-time-slider-slidebar {
+    @apply mt-2 mb-2 ml-0 mr-0 w-full h-1 bg-[#d3e5d7] rounded-sm appearance-none cursor-pointer;
+  }
 }
 
 .fa-solid {

--- a/src/components/layer-manager/layer-item/layer-item-background.vue
+++ b/src/components/layer-manager/layer-item/layer-item-background.vue
@@ -39,6 +39,7 @@ function getLabel() {
     <button
       v-if="showEditButton"
       class="fa fa-pencil"
+      :aria-label="t('Open editor panel', { ns: 'client' })"
       :title="t('Open editor panel', { ns: 'client' })"
       @click="$emit('clickEdit')"
     ></button>

--- a/src/components/layer-manager/layer-item/layer-item-sub.vue
+++ b/src/components/layer-manager/layer-item/layer-item-sub.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ShallowRef, shallowRef } from 'vue'
+
+import { useLayer } from '@/composables/layer'
+import { Layer } from '@/stores/map.store.model'
+
+const props = defineProps<{
+  layer: Layer
+  isOpen: boolean
+  isLayerComparatorOpen: boolean
+  displayLayerComparatorOpen: boolean
+}>()
+const emit = defineEmits(['changeOpacity', 'clickToggleLayerComparator'])
+const { t, getLabel } = useLayer(props.layer as Layer, { emit })
+
+const opacity: ShallowRef<number | undefined> = shallowRef(
+  (props.layer?.opacity ?? 1) * 100
+)
+const prevOpacity: ShallowRef<number | undefined> = shallowRef(
+  ((props.layer?.previousOpacity ?? opacity.value) as number) * 100
+)
+
+function onToggleVisibility() {
+  if (opacity.value === 0) {
+    opacity.value = prevOpacity.value
+  } else {
+    prevOpacity.value = opacity.value
+    opacity.value = 0
+  }
+
+  dispatchChangeOpacity()
+}
+
+function onChangeOpacity(event: Event) {
+  if (event.target) {
+    opacity.value = parseInt((event.target as HTMLInputElement).value)
+
+    dispatchChangeOpacity()
+  }
+}
+
+function onToggleLayerComparator() {
+  emit('clickToggleLayerComparator', props.layer)
+}
+
+function dispatchChangeOpacity() {
+  emit('changeOpacity', props.layer, opacity.value)
+}
+</script>
+
+<template>
+  <div
+    class="lux-layer-manager-item-content"
+    :class="isOpen ? 'h-6' : 'h-0'"
+    :id="`layer-manager-item-content-${layer.id}`"
+  >
+    <button
+      class="w-5 fa-solid"
+      role="switch"
+      :aria-checked="opacity === 0"
+      :class="opacity === 0 ? 'fa-eye-slash' : 'fa-eye'"
+      :title="
+        t('Toggle layer opacity for {{layerName}}', {
+          layerName: t(layer.name),
+        })
+      "
+      @click="onToggleVisibility"
+    ></button>
+    <input
+      :id="`${layer.id}-steps-range`"
+      type="range"
+      min="0"
+      max="100"
+      :value="opacity"
+      step="25"
+      @change="onChangeOpacity"
+      class="m-2.5 w-16 h-[5px] rounded-lg appearance-none cursor-pointer"
+      :aria-label="
+        t('Change opacity for {{ layerName }}', { layerName: getLabel() })
+      "
+    />
+    <button
+      v-if="displayLayerComparatorOpen"
+      role="switch"
+      class="fa ml-auto text-sm cursor-pointer"
+      :class="isLayerComparatorOpen ? 'fa-adjust' : 'fa-circle'"
+      :aria-checked="isLayerComparatorOpen"
+      :aria-label="
+        t('Toggle layer comparator for {{ layerName }}', {
+          layerName: getLabel(),
+        })
+      "
+      @click="onToggleLayerComparator"
+    ></button>
+  </div>
+</template>

--- a/src/components/layer-manager/layer-item/layer-item.spec.ts
+++ b/src/components/layer-manager/layer-item/layer-item.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import { Layer } from '@/stores/map.store.model'
 import LayerItem from './layer-item.vue'
@@ -12,11 +12,10 @@ const layerMock = {
 } as Layer
 
 const onClickInfo = vi.fn()
-const onClickToggle = vi.fn()
 
 describe('LayerItem', () => {
   it('renders properly', () => {
-    const wrapper = shallowMount(LayerItem, {
+    const wrapper = mount(LayerItem, {
       props: {
         layer: layerMock,
         draggableClassName: 'classnamedragg',
@@ -35,7 +34,7 @@ describe('LayerItem', () => {
   })
 
   it('renders properly when is open', () => {
-    const wrapper = shallowMount(LayerItem, {
+    const wrapper = mount(LayerItem, {
       props: {
         layer: layerMock,
         draggableClassName: 'classnamedragg',
@@ -51,9 +50,9 @@ describe('LayerItem', () => {
   })
 
   describe('actions', () => {
-    const wrapper = shallowMount(LayerItem, {
+    const wrapper = mount(LayerItem, {
       global: {
-        mocks: { onClickInfo, onClickToggle },
+        mocks: { onClickInfo },
       },
       props: {
         layer: layerMock,
@@ -69,18 +68,18 @@ describe('LayerItem', () => {
       expect(onClickInfo).toBeCalled()
     })
 
-    it('triggers #onClickToggle', async () => {
+    it('triggers #clickToggle', async () => {
       await wrapper.findAll('button')[2].trigger('click')
-      expect(onClickToggle).toBeCalled()
+      expect(wrapper.emitted().clickToggle).toBeTruthy()
     })
 
-    it('emits #onClickRemove', async () => {
-      await wrapper.findAll('button')[4].trigger('click')
+    it('emits #clickRemove', async () => {
+      await wrapper.findAll('button')[3].trigger('click')
       expect(wrapper.emitted().clickRemove).toBeTruthy()
     })
 
     it('triggers #onToggleVisibility emits #changeOpacity', async () => {
-      await wrapper.findAll('button')[5].trigger('click')
+      await wrapper.findAll('button')[4].trigger('click')
       expect(wrapper.emitted().changeOpacity).toBeTruthy()
     })
 

--- a/src/components/layer-manager/layer-item/layer-item.vue
+++ b/src/components/layer-manager/layer-item/layer-item.vue
@@ -2,7 +2,10 @@
 import { computed, ShallowRef, shallowRef } from 'vue'
 
 import { useLayer } from '@/composables/layer'
-import { Layer } from '@/stores/map.store.model'
+import { Layer, LayerTimeWidget } from '@/stores/map.store.model'
+
+import LayerTimeDatepicker from '../layer-time/layer-time-datepicker.vue'
+import LayerTimeSlider from '../layer-time/layer-time-slider.vue'
 
 const props = defineProps<{
   layer: Layer
@@ -158,5 +161,18 @@ function dispatchChangeOpacity() {
         @click="onToggleLayerComparator"
       ></button>
     </div>
+
+    <!-- Layer time: slider widget -->
+    <layer-time-slider
+      v-if="layer.time && layer.time?.widget === LayerTimeWidget.SLIDER"
+      :layer="layer"
+    ></layer-time-slider>
+
+    <!-- Layer time: datepicker widget -->
+    <layer-time-datepicker
+      v-if="layer.time && layer.time?.widget === LayerTimeWidget.DATEPICKER"
+      :layer="layer"
+      class="mb-1"
+    ></layer-time-datepicker>
   </div>
 </template>

--- a/src/components/layer-manager/layer-manager.vue
+++ b/src/components/layer-manager/layer-manager.vue
@@ -58,6 +58,10 @@ function changeOpacityLayer(layer: Layer, opacity: number) {
   mapStore.setLayerOpacity(layer.id as number, opacity / 100) // TODO: replace "as number"
 }
 
+function changeTime(layer: Layer, dateStart?: string, dateEnd?: string) {
+  mapStore.setLayerTime(layer.id as number, dateStart, dateEnd)
+}
+
 function removeLayer(layer: Layer) {
   mapStore.removeLayers(layer.id)
 }
@@ -95,6 +99,9 @@ function toggleLayerComparator() {
           @clickToggleLayerComparator="toggleLayerComparator"
           @clickInfo="setMetadataId(layer.id)"
           @changeOpacity="changeOpacityLayer"
+          @changeTime="
+            (dateStart, dateEnd) => changeTime(layer, dateStart, dateEnd)
+          "
         >
         </layer-item>
       </li>

--- a/src/components/layer-manager/layer-manager.vue
+++ b/src/components/layer-manager/layer-manager.vue
@@ -12,8 +12,8 @@ import { BLANK_BACKGROUNDLAYER } from '@/composables/background-layer/background
 import useMvtStyles from '@/composables/mvt-styles/mvt-styles.composable'
 import { useSliderComparatorStore } from '@/stores/slider-comparator.store'
 
-import LayerManagerItemBackground from './layer-item/layer-item-background.vue'
-import LayerManagerItem from './layer-item/layer-item.vue'
+import LayerItemBackground from './layer-item/layer-item-background.vue'
+import LayerItem from './layer-item/layer-item.vue'
 
 const { t } = useTranslation()
 
@@ -76,51 +76,52 @@ function toggleLayerComparator() {
 </script>
 
 <template>
-  <ul id="sortable-layers">
-    <li
-      v-for="(layer, index) in layers"
-      :key="layer.id"
-      :id="(layer.id as string)"
-      data-cy="myLayer"
+  <div>
+    <ul id="sortable-layers">
+      <li
+        v-for="(layer, index) in layers"
+        :key="layer.id"
+        :id="(layer.id as string)"
+        data-cy="myLayer"
+      >
+        <layer-item
+          :draggableClassName="draggableClassName"
+          :layer="layer"
+          :isOpen="isLayerOpenId === layer.id"
+          :isLayerComparatorOpen="sliderActive"
+          :displayLayerComparatorOpen="index === 0"
+          @clickRemove="removeLayer"
+          @clickToggle="toggleAccordionItem"
+          @clickToggleLayerComparator="toggleLayerComparator"
+          @clickInfo="setMetadataId(layer.id)"
+          @changeOpacity="changeOpacityLayer"
+        >
+        </layer-item>
+      </li>
+    </ul>
+
+    <layer-item-background
+      :layer="bgLayer || BLANK_BACKGROUNDLAYER"
+      :showEditButton="bgLayerIsEditable"
+      @clickInfo="() => bgLayer && setMetadataId(bgLayer.id)"
+      @clickEdit="openEditionLayer"
     >
-      <layer-manager-item
-        :draggableClassName="draggableClassName"
-        :layer="layer"
-        :isOpen="isLayerOpenId === layer.id"
-        :isLayerComparatorOpen="sliderActive"
-        :displayLayerComparatorOpen="index === 0"
-        @clickRemove="removeLayer"
-        @clickToggle="toggleAccordionItem"
-        @clickToggleLayerComparator="toggleLayerComparator"
-        @clickInfo="setMetadataId(layer.id)"
-        @changeOpacity="changeOpacityLayer"
+    </layer-item-background>
+    <div class="flex flex-row justify-center space-x-1 my-2">
+      <button
+        data-cy="addLayer"
+        class="bg-white text-primary hover:bg-primary hover:text-white border border-slate-300 py-1.5 px-2.5"
+        @click="emit('displayCatalog')"
       >
-      </layer-manager-item>
-    </li>
-    <li>
-      <layer-manager-item-background
-        :layer="bgLayer || BLANK_BACKGROUNDLAYER"
-        :showEditButton="bgLayerIsEditable"
-        @clickInfo="() => bgLayer && setMetadataId(bgLayer.id)"
-        @clickEdit="openEditionLayer"
+        {{ t('+ Add layers', { ns: 'client' }) }}
+      </button>
+      <button
+        data-cy="addRemoteLayer"
+        class="bg-white text-primary hover:bg-primary hover:text-white border border-slate-300 py-1.5 px-2.5"
+        @click="setRemoteLayersOpen(true)"
       >
-      </layer-manager-item-background>
-      <div class="flex flex-row justify-center space-x-1 my-2">
-        <button
-          data-cy="addLayer"
-          class="bg-white text-primary hover:bg-primary hover:text-white border border-slate-300 py-1.5 px-2.5"
-          @click="emit('displayCatalog')"
-        >
-          {{ t('+ Add layers', { ns: 'client' }) }}
-        </button>
-        <button
-          data-cy="addRemoteLayer"
-          class="bg-white text-primary hover:bg-primary hover:text-white border border-slate-300 py-1.5 px-2.5"
-          @click="setRemoteLayersOpen(true)"
-        >
-          {{ t('+ Add external Wms', { ns: 'client' }) }}
-        </button>
-      </div>
-    </li>
-  </ul>
+        {{ t('+ Add external Wms', { ns: 'client' }) }}
+      </button>
+    </div>
+  </div>
 </template>

--- a/src/components/layer-manager/layer-time/layer-time-datepicker-range.vue
+++ b/src/components/layer-manager/layer-time/layer-time-datepicker-range.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ShallowRef, shallowRef } from 'vue'
+import { useTranslation } from 'i18next-vue'
+
+import { Layer } from '@/stores/map.store.model'
+import LayerTimeDatepicker from './layer-time-datepicker.vue'
+
+const { t } = useTranslation()
+const props = defineProps<{
+  layer: Layer
+}>()
+const emit = defineEmits<{
+  (e: 'changeTime', dateStart?: string, dateEnd?: string): void
+}>()
+const dateValueStart: ShallowRef<string | undefined> = shallowRef(
+  props.layer.currentTimeMinValue
+)
+const dateValueEnd: ShallowRef<string | undefined> = shallowRef(
+  props.layer.currentTimeMaxValue
+)
+
+function onChangeDateStart(dateValue: string) {
+  emit('changeTime', dateValue, props.layer.currentTimeMaxValue)
+}
+
+function onChangeDateEnd(dateValue: string) {
+  emit('changeTime', props.layer.currentTimeMinValue, dateValue)
+}
+</script>
+
+<template>
+  <div class="lux-time-slider w-full">
+    <!-- Date START datepicker input -->
+    <div>
+      <label
+        :for="`${layer.id}-time-slider-start`"
+        class="lux-time-slider-label"
+      >
+        {{ t('From:') }}
+      </label>
+      <layer-time-datepicker
+        :id="`${layer.id}-time-slider-start`"
+        :date-value="dateValueStart"
+        :min-date-allowed="props.layer.time?.minValue"
+        :max-date-allowed="props.layer.time?.maxValue"
+        @change="onChangeDateStart"
+      />
+    </div>
+
+    <!-- Date END datepicker input -->
+    <div>
+      <label :for="`${layer.id}-time-slider-end`" class="lux-time-slider-label">
+        {{ t('To:') }}
+      </label>
+      <layer-time-datepicker
+        :id="`${layer.id}-time-slider-end`"
+        :date-value="dateValueEnd"
+        :min-date-allowed="props.layer.time?.minValue"
+        :max-date-allowed="props.layer.time?.maxValue"
+        @change="onChangeDateEnd"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/layer-manager/layer-time/layer-time-datepicker-value.vue
+++ b/src/components/layer-manager/layer-time/layer-time-datepicker-value.vue
@@ -31,7 +31,7 @@ const dateValue: ShallowRef<string | undefined> = shallowRef(
         :date-value="dateValue"
         :min-date-allowed="props.layer.time?.minValue"
         :max-date-allowed="props.layer.time?.maxValue"
-        @change="$emit('changeTime', dateValue)"
+        @change="$emit('changeTime', $event)"
       />
     </div>
   </div>

--- a/src/components/layer-manager/layer-time/layer-time-datepicker-value.vue
+++ b/src/components/layer-manager/layer-time/layer-time-datepicker-value.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ShallowRef, shallowRef } from 'vue'
+import { useTranslation } from 'i18next-vue'
+
+import { Layer } from '@/stores/map.store.model'
+import LayerTimeDatepicker from './layer-time-datepicker.vue'
+
+const { t } = useTranslation()
+const props = defineProps<{
+  layer: Layer
+}>()
+defineEmits<{
+  (e: 'changeTime', dateStart: string): void
+}>()
+const dateValue: ShallowRef<string | undefined> = shallowRef(
+  props.layer.currentTimeMinValue
+)
+</script>
+
+<template>
+  <div class="lux-time-slider w-full">
+    <div>
+      <label
+        :for="`${layer.id}-time-slider-start`"
+        class="lux-time-slider-label"
+      >
+        {{ t('Date:') }}
+      </label>
+      <layer-time-datepicker
+        :id="`${layer.id}-time-slider-start`"
+        :date-value="dateValue"
+        :min-date-allowed="props.layer.time?.minValue"
+        :max-date-allowed="props.layer.time?.maxValue"
+        @change="$emit('changeTime', dateValue)"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/layer-manager/layer-time/layer-time-datepicker.vue
+++ b/src/components/layer-manager/layer-time/layer-time-datepicker.vue
@@ -1,55 +1,38 @@
 <script setup lang="ts">
-import { ShallowRef, shallowRef } from 'vue'
-import { useTranslation } from 'i18next-vue'
+import { computed } from 'vue'
+import { formatDateForInput } from '@/services/time.utils'
 
-import { Layer, LayerTimeSlider, LayerTimeMode } from '@/stores/map.store.model'
+const props = withDefaults(
+  defineProps<{
+    minDateAllowed?: string
+    maxDateAllowed?: string
+    dateValue?: string
+  }>(),
+  {
+    minDateAllowed: '',
+    maxDateAllowed: '',
+  }
+)
 
-const { t } = useTranslation()
-const props = defineProps<{
-  layer: Layer
+const emit = defineEmits<{
+  (e: 'change', dateValue: string): void
 }>()
-defineEmits<{
-  (e: 'changeRange'): void
-}>()
-const layerTime = <LayerTimeSlider>props.layer.time
-const dateValueStart: ShallowRef<string | undefined> = shallowRef(
-  props.layer.currentTime
-)
-const dateValueEnd: ShallowRef<string | undefined> = shallowRef(
-  props.layer.currentTime
-)
+
+const minValue = computed(() => formatDateForInput(props.minDateAllowed))
+const maxValue = computed(() => formatDateForInput(props.maxDateAllowed))
+
+function onChange(event: Event) {
+  emit('change', (event.target as HTMLInputElement).value)
+}
 </script>
 
 <template>
-  <span class="font-bold">{{ t('Distance:') }}</span>
-  <div class="lux-time-slider w-full">
-    <div>
-      <label :for="`${layer.id}-time-slider-start`" class="mr-1">
-        {{
-          layerTime.mode === LayerTimeMode.RANGE
-            ? t('From:', { nsSeparator: '|' })
-            : t('Date:', { nsSeparator: '|' })
-        }}
-      </label>
-      <input
-        :id="`${layer.id}-time-slider-start`"
-        class="border-[#767676] border-[1px] pl-1"
-        type="date"
-        v-model="dateValueStart"
-        @change="$emit('changeDateStart', dateValueStart)"
-      />
-    </div>
-    <div v-if="layerTime.mode === LayerTimeMode.RANGE">
-      <label :for="`${layer.id}-time-slider-end`" class="mr-1">
-        {{ t('To:', { nsSeparator: '|' }) }}
-      </label>
-      <input
-        :id="`${layer.id}-time-slider-end`"
-        class="border-[#767676] border-[1px] pl-1"
-        type="date"
-        v-model="dateValueEnd"
-        @change="$emit('changeDateEnd', dateValueEnd)"
-      />
-    </div>
-  </div>
+  <input
+    class="lux-time-slider-datepicker"
+    type="date"
+    :min="minValue"
+    :max="maxValue"
+    :value="dateValue ? formatDateForInput(dateValue) : ''"
+    @change="onChange"
+  />
 </template>

--- a/src/components/layer-manager/layer-time/layer-time-datepicker.vue
+++ b/src/components/layer-manager/layer-time/layer-time-datepicker.vue
@@ -28,7 +28,7 @@ function onChange(event: Event) {
 
 <template>
   <input
-    class="lux-time-slider-datepicker"
+    class="lux-time-datepicker"
     type="date"
     :min="minValue"
     :max="maxValue"

--- a/src/components/layer-manager/layer-time/layer-time-datepicker.vue
+++ b/src/components/layer-manager/layer-time/layer-time-datepicker.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ShallowRef, shallowRef } from 'vue'
+import { useTranslation } from 'i18next-vue'
+
+import { Layer, LayerTimeSlider, LayerTimeMode } from '@/stores/map.store.model'
+
+const { t } = useTranslation()
+const props = defineProps<{
+  layer: Layer
+}>()
+defineEmits<{
+  (e: 'changeRange'): void
+}>()
+const layerTime = <LayerTimeSlider>props.layer.time
+const dateValueStart: ShallowRef<string | undefined> = shallowRef(
+  props.layer.currentTime
+)
+const dateValueEnd: ShallowRef<string | undefined> = shallowRef(
+  props.layer.currentTime
+)
+</script>
+
+<template>
+  <span class="font-bold">{{ t('Distance:') }}</span>
+  <div class="lux-time-slider w-full">
+    <div>
+      <label :for="`${layer.id}-time-slider-start`" class="mr-1">
+        {{
+          layerTime.mode === LayerTimeMode.RANGE
+            ? t('From:', { nsSeparator: '|' })
+            : t('Date:', { nsSeparator: '|' })
+        }}
+      </label>
+      <input
+        :id="`${layer.id}-time-slider-start`"
+        class="border-[#767676] border-[1px] pl-1"
+        type="date"
+        v-model="dateValueStart"
+        @change="$emit('changeDateStart', dateValueStart)"
+      />
+    </div>
+    <div v-if="layerTime.mode === LayerTimeMode.RANGE">
+      <label :for="`${layer.id}-time-slider-end`" class="mr-1">
+        {{ t('To:', { nsSeparator: '|' }) }}
+      </label>
+      <input
+        :id="`${layer.id}-time-slider-end`"
+        class="border-[#767676] border-[1px] pl-1"
+        type="date"
+        v-model="dateValueEnd"
+        @change="$emit('changeDateEnd', dateValueEnd)"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/layer-manager/layer-time/layer-time-slider.vue
+++ b/src/components/layer-manager/layer-time/layer-time-slider.vue
@@ -1,16 +1,82 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import { formatTimeValue } from '@/services/time.utils'
-import { Layer, LayerTimeMode, LayerTimeSlider } from '@/stores/map.store.model'
-import { ShallowRef, shallowRef } from 'vue'
+import { Layer, LayerTimeMode } from '@/stores/map.store.model'
 
 const props = defineProps<{
   layer: Layer
 }>()
-defineEmits<{
-  (e: 'changeRange'): void
+const emit = defineEmits<{
+  (e: 'changeTime', dateStart: string): void
 }>()
-const layerTime = <LayerTimeSlider>props.layer.time
-const sliderValue: ShallowRef<number | undefined> = shallowRef(undefined)
+
+const sliderValue = computed(() =>
+  props.layer.time?.values?.findIndex(
+    val => val === props.layer.currentTimeMinValue
+  )
+)
+const timeValues = computed(computeTimeValues)
+const sliderNbSteps = computed(() => timeValues.value?.length)
+
+function computeTimeValues() {
+  // Copy from legacy function in v3: timeSliderComponent getTimeValueList_()
+  const layerTime = props.layer.time
+  const timeValueList: number[] = []
+
+  if (!layerTime) {
+    return timeValueList
+  }
+
+  if (layerTime.values) {
+    return layerTime.values
+  }
+
+  // maxValue == null means the UI shall use the current date
+  const minDate = new Date(layerTime.minValue)
+  const maxDate = new Date(layerTime.maxValue ?? Date.now())
+  const maxNbValues = 1024
+  const endDate = new Date(minDate.getTime())
+  const layerTimeInterval = layerTime.interval ?? [0, 1, 0, 0]
+
+  endDate.setFullYear(
+    minDate.getFullYear() + maxNbValues * layerTimeInterval[0]
+  )
+  endDate.setMonth(
+    minDate.getMonth() + maxNbValues * layerTimeInterval[1],
+    minDate.getDate() + maxNbValues * layerTimeInterval[2]
+  )
+  endDate.setSeconds(minDate.getSeconds() + maxNbValues * layerTimeInterval[3])
+
+  if (endDate > maxDate) {
+    // Transform interval to a list of values when the number
+    // of values is below a threshold (maxNbValues)
+    for (let i = 0; ; i++) {
+      const nextDate = new Date(minDate.getTime())
+      nextDate.setFullYear(minDate.getFullYear() + i * layerTimeInterval[0])
+      nextDate.setMonth(
+        minDate.getMonth() + i * layerTimeInterval[1],
+        minDate.getDate() + i * layerTimeInterval[2]
+      )
+      nextDate.setSeconds(minDate.getSeconds() + i * layerTimeInterval[3])
+
+      if (nextDate <= maxDate) {
+        timeValueList.push(nextDate.getTime())
+      } else {
+        break
+      }
+    }
+  }
+
+  return timeValueList
+}
+
+function onChange(event: Event) {
+  const cursorIndex = parseInt((event.target as HTMLInputElement).value)
+  const selectedTimeValue = timeValues.value[cursorIndex]
+
+  emit('changeTime', new Date(selectedTimeValue).toISOString())
+}
 </script>
 
 <template>
@@ -18,13 +84,12 @@ const sliderValue: ShallowRef<number | undefined> = shallowRef(undefined)
     <!-- Slider -->
     <div>
       <input
-        class="mt-2 mb-2 ml-0 mr-0 w-full h-1 bg-[#d3e5d7] rounded-sm appearance-none cursor-pointer"
-        type="range"
+        class="lux-time-slider-slidebar"
         min="0"
-        max="100"
-        step="25"
-        v-model="sliderValue"
-        @change="$emit('changeRange', sliderValue)"
+        type="range"
+        :max="sliderNbSteps - 1"
+        :value="sliderValue"
+        @change="onChange"
       />
     </div>
 
@@ -32,19 +97,15 @@ const sliderValue: ShallowRef<number | undefined> = shallowRef(undefined)
     <div class="lux-time-slider-displayed-dates">
       <div
         class="lux-time-slider-start-date"
-        v-if="layer.time?.mode === LayerTimeMode.RANGE"
+        v-if="
+          layer.time?.mode === LayerTimeMode.RANGE ||
+          layer.time?.mode === LayerTimeMode.VALUE
+        "
       >
         <span>{{
-          formatTimeValue(123 /*layer.time?.values[0]*/, layerTime.resolution)
-        }}</span>
-      </div>
-
-      <div
-        class="lux-time-slider-start-date"
-        v-if="layer.time?.mode === LayerTimeMode.VALUE"
-      >
-        <span>{{
-          formatTimeValue(123 /*layer.time?.values*/, layerTime.resolution)
+          layer.currentTimeMinValue
+            ? formatTimeValue(layer.currentTimeMinValue, layer.time?.resolution)
+            : '-'
         }}</span>
       </div>
 
@@ -53,7 +114,9 @@ const sliderValue: ShallowRef<number | undefined> = shallowRef(undefined)
         v-if="layer.time?.mode === LayerTimeMode.RANGE"
       >
         <span>{{
-          formatTimeValue(123 /*layer.time?.values[1]*/, layerTime.resolution)
+          layer.currentTimeMaxValue
+            ? formatTimeValue(layer.currentTimeMaxValue, layer.time?.resolution)
+            : '-'
         }}</span>
       </div>
     </div>

--- a/src/components/layer-manager/layer-time/layer-time-slider.vue
+++ b/src/components/layer-manager/layer-time/layer-time-slider.vue
@@ -84,7 +84,7 @@ function onChange(event: Event) {
     <!-- Slider -->
     <div>
       <input
-        class="lux-time-slider-slidebar"
+        class="lux-time-slidebar"
         min="0"
         type="range"
         :max="sliderNbSteps - 1"

--- a/src/components/layer-manager/layer-time/layer-time-slider.vue
+++ b/src/components/layer-manager/layer-time/layer-time-slider.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { formatTimeValue } from '@/services/time.utils'
+import { Layer, LayerTimeMode, LayerTimeSlider } from '@/stores/map.store.model'
+import { ShallowRef, shallowRef } from 'vue'
+
+const props = defineProps<{
+  layer: Layer
+}>()
+defineEmits<{
+  (e: 'changeRange'): void
+}>()
+const layerTime = <LayerTimeSlider>props.layer.time
+const sliderValue: ShallowRef<number | undefined> = shallowRef(undefined)
+</script>
+
+<template>
+  <div class="lux-time-slider w-full">
+    <!-- Slider -->
+    <div>
+      <input
+        class="mt-2 mb-2 ml-0 mr-0 w-full h-1 bg-[#d3e5d7] rounded-sm appearance-none cursor-pointer"
+        type="range"
+        min="0"
+        max="100"
+        step="25"
+        v-model="sliderValue"
+        @change="$emit('changeRange', sliderValue)"
+      />
+    </div>
+
+    <!-- Display localized time values -->
+    <div class="lux-time-slider-displayed-dates">
+      <div
+        class="lux-time-slider-start-date"
+        v-if="layer.time?.mode === LayerTimeMode.RANGE"
+      >
+        <span>{{
+          formatTimeValue(123 /*layer.time?.values[0]*/, layerTime.resolution)
+        }}</span>
+      </div>
+
+      <div
+        class="lux-time-slider-start-date"
+        v-if="layer.time?.mode === LayerTimeMode.VALUE"
+      >
+        <span>{{
+          formatTimeValue(123 /*layer.time?.values*/, layerTime.resolution)
+        }}</span>
+      </div>
+
+      <div
+        class="lux-time-slider-end-date"
+        v-if="layer.time?.mode === LayerTimeMode.RANGE"
+      >
+        <span>{{
+          formatTimeValue(123 /*layer.time?.values[1]*/, layerTime.resolution)
+        }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/layer-manager/layer-time/layer-time.vue
+++ b/src/components/layer-manager/layer-time/layer-time.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { Layer, LayerTimeMode, LayerTimeWidget } from '@/stores/map.store.model'
+
+import LayerTimeDatepickerValue from '../layer-time/layer-time-datepicker-value.vue'
+import LayerTimeDatepickerRange from '../layer-time/layer-time-datepicker-range.vue'
+import LayerTimeSlider from '../layer-time/layer-time-slider.vue'
+
+defineProps<{
+  layer: Layer
+}>()
+
+const emit = defineEmits<{
+  (e: 'changeTime', dateStart?: string, dateEnd?: string): void
+}>()
+
+function onChangeTime(dateStart?: string, dateEnd?: string) {
+  emit('changeTime', dateStart, dateEnd)
+}
+</script>
+
+<template>
+  <!-- Layer time: slider widget -->
+  <layer-time-slider
+    v-if="layer.time?.widget === LayerTimeWidget.SLIDER"
+    :layer="layer"
+    @changeTime="onChangeTime"
+  ></layer-time-slider>
+
+  <!-- Layer time: datepicker VALUE (one date) widget -->
+  <layer-time-datepicker-value
+    v-if="
+      layer.time?.widget === LayerTimeWidget.DATEPICKER &&
+      layer.time?.mode === LayerTimeMode.VALUE
+    "
+    :layer="layer"
+    @changeTime="onChangeTime"
+  ></layer-time-datepicker-value>
+
+  <!-- Layer time: datepicker RANGE ("from:" date - "to:" date) widget -->
+  <layer-time-datepicker-range
+    v-if="
+      layer.time?.widget === LayerTimeWidget.DATEPICKER &&
+      layer.time?.mode === LayerTimeMode.RANGE
+    "
+    :layer="layer"
+    @changeTime="onChangeTime"
+  ></layer-time-datepicker-range>
+</template>

--- a/src/composables/layers/layers.composable.ts
+++ b/src/composables/layers/layers.composable.ts
@@ -24,6 +24,7 @@ export default function useLayers() {
 
   function initLayer(layer: Layer) {
     layer.opacity = layer.previousOpacity = layer.metadata?.start_opacity ?? 1
+
     return layer
   }
 

--- a/src/composables/layers/layers.composable.ts
+++ b/src/composables/layers/layers.composable.ts
@@ -1,6 +1,10 @@
 import i18next from 'i18next'
 
-import type { Layer, LayerId } from '@/stores/map.store.model'
+import {
+  Layer,
+  LayerId,
+  LAYER_CURRENT_TIME_SEPARATOR,
+} from '@/stores/map.store.model'
 import { useMapStore } from '@/stores/map.store'
 import { useThemeStore } from '@/stores/config.store'
 import useThemes from '@/composables/themes/themes.composable'
@@ -22,10 +26,44 @@ export default function useLayers() {
     }
   }
 
+  /**
+   * Initialize the layer's opacity and time
+   *
+   * @param layer The layer spec, will be modified
+   * @returns The layer that have been modified
+   */
   function initLayer(layer: Layer) {
     layer.opacity = layer.previousOpacity = layer.metadata?.start_opacity ?? 1
+    initLayerCurrentTime(layer)
 
     return layer
+  }
+
+  /**
+   * Initialize layer's currentTimeMinValue and currentTimeMaxValue.
+   * Code legacy can be found in: ngeo.Time.getOptions()
+   *
+   * - currentTimeMinValue and currentTimeMaxValue comming from permalink if any (untouched here)
+   * - if not, retrieve from time options (from spec/fixtures)
+   * @param layer The layer spec, will be modified
+   */
+  function initLayerCurrentTime(layer: Layer) {
+    if (!layer.currentTimeMinValue) {
+      layer.currentTimeMinValue =
+        layer.time?.minDefValue ?? layer.time?.minValue
+    }
+
+    if (!layer.currentTimeMaxValue) {
+      layer.currentTimeMaxValue =
+        layer.time?.maxDefValue ?? layer.time?.maxValue
+    }
+  }
+
+  function getLayerCurrentTime(layer: Layer) {
+    return [
+      layer.currentTimeMinValue,
+      ...([layer.currentTimeMaxValue] || []),
+    ].join(LAYER_CURRENT_TIME_SEPARATOR)
   }
 
   function handleExclusionLayers(layer: Layer) {
@@ -88,6 +126,7 @@ export default function useLayers() {
 
   return {
     initLayer,
+    getLayerCurrentTime,
     handleExclusionLayers,
     toggleLayer,
   }

--- a/src/composables/layers/layers.composable.ts
+++ b/src/composables/layers/layers.composable.ts
@@ -62,7 +62,7 @@ export default function useLayers() {
   function getLayerCurrentTime(layer: Layer) {
     return [
       layer.currentTimeMinValue,
-      ...([layer.currentTimeMaxValue] || []),
+      ...(layer.currentTimeMaxValue ? [layer.currentTimeMaxValue] : []),
     ].join(LAYER_CURRENT_TIME_SEPARATOR)
   }
 

--- a/src/composables/map/map.composable.ts
+++ b/src/composables/map/map.composable.ts
@@ -34,16 +34,23 @@ export default function useMap() {
   }
 
   function equalsLayer(layerA: Layer, layerB: Layer) {
+    return layerA.id === layerB.id
+  }
+
+  function strictEqualsLayer(
+    layerA: Layer | undefined,
+    layerB: Layer | undefined
+  ) {
     return layerA === layerB
   }
 
   function hasLayer(context: MapContext, layer: Layer) {
-    return context.layers?.some(l => equalsLayer(layer, l))
+    return context.layers?.some(l => equalsLayer(l, layer))
   }
 
   function layerHasChanged(oldContext: MapContext | null, layer: Layer) {
-    const oldLayer = oldContext?.layers?.find(l => l.id === layer.id)
-    return oldLayer !== layer
+    const oldLayer = oldContext?.layers?.find(l => equalsLayer(l, layer))
+    return !strictEqualsLayer(oldLayer, layer)
   }
 
   function contextHasChanged(

--- a/src/composables/themes/themes.model.ts
+++ b/src/composables/themes/themes.model.ts
@@ -72,8 +72,18 @@ export interface ThemeNodeModel {
   children?: ThemeNodeModel[]
   mixed?: boolean
   childLayers?: {
-    name: string
+    name?: string
   }[]
   functionalities?: {}
-  time?: { [key: string]: string | string[] | null }
+  time?: {
+    minValue: string
+    maxValue: string
+    minDefValue?: string | null
+    maxDefValue?: string | null
+    mode: string
+    resolution: string
+    widget: string
+    values?: string[]
+    interval?: number[]
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ i18next.init({
   backend: {
     loadPath: `${import.meta.env.BASE_URL}assets/locales/{{ns}}.{{lng}}.json`, // ! use assets instead of ./assets because of theme path in url
   },
+  nsSeparator: '|', // ! force separator to '|' instead of ':' because some i18n keys have ':' (otherwise, i18next doesn't find the key)
 })
 
 const app = createApp(App)

--- a/src/services/layer-metadata/layer-metadata.service.spec.ts
+++ b/src/services/layer-metadata/layer-metadata.service.spec.ts
@@ -1,3 +1,12 @@
+const useThemesMock = {
+  findById: vi.fn(id => (id === 268 ? themeNodeMock : undefined)),
+  findBgLayerById: vi.fn(id => (id === 556 ? bgNodeMock : undefined)),
+}
+
+vi.mock('@/composables/themes/themes.composable', () => ({
+  default: () => useThemesMock,
+}))
+
 import { ThemeNodeModel } from '@/composables/themes/themes.model'
 import { layerMetadataService } from './layer-metadata.service'
 import { remoteMetadataHelper } from './remote-metadata.helper'
@@ -42,14 +51,6 @@ const bgNodeMock: ThemeNodeModel = {
   previousOpacity: 1,
   opacity: 1,
 }
-
-const useThemesMock = {
-  findById: vi.fn(id => (id === 268 ? themeNodeMock : undefined)),
-  findBgLayerById: vi.fn(id => (id === 556 ? bgNodeMock : undefined)),
-}
-vi.mock('@/composables/themes/themes.composable', () => ({
-  default: () => useThemesMock,
-}))
 
 const metadataMock = {
   title: 'Title that will be ignored on internal layer',

--- a/src/services/state-persistor/state-persistor-layer.mapper.spec.ts
+++ b/src/services/state-persistor/state-persistor-layer.mapper.spec.ts
@@ -81,6 +81,8 @@ describe('StorageLayerMapper', () => {
           imageType: '',
           opacity: 1,
           previousOpacity: 1,
+          currentTimeMinValue: undefined,
+          currentTimeMaxValue: undefined,
         },
         {
           id: 360,
@@ -90,6 +92,8 @@ describe('StorageLayerMapper', () => {
           imageType: '',
           opacity: 1,
           previousOpacity: 1,
+          currentTimeMinValue: undefined,
+          currentTimeMaxValue: undefined,
         },
       ])
     })
@@ -105,6 +109,8 @@ describe('StorageLayerMapper', () => {
             imageType: '',
             opacity: 1,
             previousOpacity: 1,
+            currentTimeMinValue: undefined,
+            currentTimeMaxValue: undefined,
           },
           undefined,
           {
@@ -115,6 +121,8 @@ describe('StorageLayerMapper', () => {
             imageType: '',
             opacity: 1,
             previousOpacity: 1,
+            currentTimeMinValue: undefined,
+            currentTimeMaxValue: undefined,
           },
         ]
       )
@@ -130,6 +138,8 @@ describe('StorageLayerMapper', () => {
           imageType: '',
           opacity: 1,
           previousOpacity: 1,
+          currentTimeMinValue: undefined,
+          currentTimeMaxValue: undefined,
         },
         undefined,
       ])
@@ -150,6 +160,8 @@ describe('StorageLayerMapper', () => {
           opacity: 1,
           previousOpacity: 1,
           url: 'https://map.geoportail.lu/httpsproxy?url=www.mysuperserver.com%2Fmytiles',
+          currentTimeMinValue: undefined,
+          currentTimeMaxValue: undefined,
         },
       ])
     })

--- a/src/services/state-persistor/state-persistor-layer.mapper.ts
+++ b/src/services/state-persistor/state-persistor-layer.mapper.ts
@@ -8,8 +8,13 @@ import { stringToBooleans, stringToNumbers } from '../utils'
 
 const STORAGE_SEPARATOR = '-'
 const STORAGE_SEPARATOR_V2 = ','
+const STORAGE_TIME_SEPARATOR = '--'
 
 class StorageLayerMapper {
+  layerTimesToStrings(layerTimesText: string | null) {
+    return layerTimesText ? layerTimesText.split(STORAGE_TIME_SEPARATOR) : []
+  }
+
   layerIdsToLayers(layerIdsText: string | null) {
     const themes = useThemes()
     const layers = useLayers()
@@ -68,6 +73,10 @@ class StorageLayerMapper {
     return (
       layers?.map(layer => layer.opacity ?? 1).join(STORAGE_SEPARATOR) || ''
     )
+  }
+
+  layersToLayerTimes(layers: Layer[] | null): string {
+    return layers?.map(layer => layer.time ?? 1).join(STORAGE_SEPARATOR) || ''
   }
 
   bgLayerNameToBgLayer(bgLayerName: string | null): Layer | null {

--- a/src/services/state-persistor/state-persistor-layer.mapper.ts
+++ b/src/services/state-persistor/state-persistor-layer.mapper.ts
@@ -76,7 +76,11 @@ class StorageLayerMapper {
   }
 
   layersToLayerTimes(layers: Layer[] | null): string {
-    return layers?.map(layer => layer.time ?? 1).join(STORAGE_SEPARATOR) || ''
+    return (
+      layers
+        ?.map(layer => useLayers().getLayerCurrentTime(layer) ?? '')
+        .join(STORAGE_TIME_SEPARATOR) || ''
+    )
   }
 
   bgLayerNameToBgLayer(bgLayerName: string | null): Layer | null {

--- a/src/services/state-persistor/state-persistor-layers.service.ts
+++ b/src/services/state-persistor/state-persistor-layers.service.ts
@@ -51,6 +51,12 @@ class StatePersistorLayersService implements StatePersistorService {
             value,
             storageLayerMapper.layersToLayerOpacities
           )
+
+          storageHelper.setValue(
+            SP_KEY_TIME_SELECTIONS,
+            value,
+            storageLayerMapper.layersToLayerTimes
+          )
         }
       },
       { immediate: true }
@@ -101,7 +107,8 @@ class StatePersistorLayersService implements StatePersistorService {
 
     if (times.length) {
       layers?.forEach(
-        (layer, index) => layer && this.restoreLayerTime(layer, times[index])
+        (layer, index) =>
+          layer && times[index] && this.restoreLayerTime(layer, times[index])
       )
     }
   }
@@ -110,11 +117,8 @@ class StatePersistorLayersService implements StatePersistorService {
     const defaultTimes = time.split('/')
 
     // Use min and max default values to restore previous state
-    layer.currentTime = time
-    layer.currentTimeMinDefValue = defaultTimes[0]
-    if (defaultTimes.length > 1) {
-      layer.currentTimeMaxDefValue = defaultTimes[1]
-    }
+    layer.currentTimeMinValue = defaultTimes[0]
+    layer.currentTimeMaxValue = defaultTimes[1]
   }
 
   getOpacitiesFromStorage() {

--- a/src/services/state-persistor/state-persistor.model.ts
+++ b/src/services/state-persistor/state-persistor.model.ts
@@ -14,6 +14,7 @@ export const SP_KEY_LAYERS = 'layers'
 export const SP_KEY_BGLAYER = 'bgLayer'
 export const SP_KEY_OPACITIES = 'opacities'
 export const SP_KEY_THEME = 'theme'
+export const SP_KEY_TIME_SELECTIONS = 'time' // !!! Separator is "--"?
 export const SP_KEY_ZOOM = 'zoom'
 export const SP_KEY_SRS = 'SRS' // TODO:
 export const SP_KEY_X = 'X'

--- a/src/services/state-persistor/storage/url-storage.ts
+++ b/src/services/state-persistor/storage/url-storage.ts
@@ -54,7 +54,8 @@ export class UrlStorage implements Storage {
   }
 
   getItem(key: string): string | null {
-    return this.getSnappedUrl().searchParams.get(key)
+    const value = this.getSnappedUrl().searchParams.get(key)
+    return value !== null ? decodeURIComponent(value) : value
   }
 
   removeItem(key: string) {

--- a/src/services/time.utils.ts
+++ b/src/services/time.utils.ts
@@ -9,7 +9,7 @@ export enum TimeResolution {
 }
 
 /**
- * Format time regarding a resolution
+ * Format time regarding a resolution (comming from i18n)
  *
  * @param time (in ms format) timestamp to format
  * @param resolution resolution to use
@@ -19,7 +19,7 @@ export enum TimeResolution {
  * @returns Date string regarding the resolution
  */
 export function formatTimeValue(
-  time: number,
+  time: number | string | Date,
   resolution: TimeResolution = TimeResolution.SECOND,
   useISOFormat?: boolean,
   toUTC?: boolean
@@ -45,9 +45,32 @@ export function formatTimeValue(
   )[resolution]
 
   return resolutionPattern
-    ? DateTime.fromFormat(
-        dateISOString,
+    ? DateTime.fromISO(dateISOString).toFormat(
         `${toUTC ? 'UTC:' : ''}${resolutionPattern}`
       )
     : dateISOString.replace(/\.\d{3}/, '')
+}
+
+/**
+ * Format a date string or timestamp to ISO date,
+ * ! but with only 2 digits before the zulu
+ *
+ * @param date  The date string or timestamp
+ * @returns The corresponding date string ISO
+ */
+export function dateToISOString(date: string | number) {
+  return new Date(date).toISOString().split('.')[0] + 'Z'
+}
+
+/**
+ * Format an ISO date string to be used as a value for <input type="date" />
+ *
+ * @param dateISO - The date ISO string
+ * @returns The date string formatted as 'yyyy-MM-dd' for input date
+ *
+ * @example
+ * formatDateForInput('2014-08-31T12:43:47Z')
+ */
+export function formatDateForInput(dateISO: string) {
+  return DateTime.fromISO(dateISO).toFormat('yyyy-MM-dd')
 }

--- a/src/services/time.utils.ts
+++ b/src/services/time.utils.ts
@@ -1,0 +1,53 @@
+import { useTranslation } from 'i18next-vue'
+import { DateTime } from 'luxon'
+
+export enum TimeResolution {
+  YEAR = 'year',
+  MONTH = 'month',
+  DAY = 'day',
+  SECOND = 'second',
+}
+
+/**
+ * Format time regarding a resolution
+ *
+ * @param time (in ms format) timestamp to format
+ * @param resolution resolution to use
+ * @param useISOFormat True to a ISO-8601 date string that can be used as a WMS-T Parameter. Otherwise, use a localized date format.
+ * @param toUTC to get the UTC date
+ *
+ * @returns Date string regarding the resolution
+ */
+export function formatTimeValue(
+  time: number,
+  resolution: TimeResolution = TimeResolution.SECOND,
+  useISOFormat?: boolean,
+  toUTC?: boolean
+) {
+  const { t } = useTranslation()
+  const dateISOString = new Date(time).toISOString()
+
+  const resolutionPatterns = {
+    [TimeResolution.YEAR]: t('yyyy'),
+    [TimeResolution.MONTH]: t('M/yyyy'),
+    [TimeResolution.DAY]: t('M/d/yyyy'),
+    [TimeResolution.SECOND]: t('M/d/yyyy HH:mm:ss'),
+  }
+  const resolutionPatternsISO = {
+    [TimeResolution.YEAR]: 'yyyy',
+    [TimeResolution.MONTH]: 'yyyy-MM',
+    [TimeResolution.DAY]: 'yyyy-MM-dd',
+    [TimeResolution.SECOND]: undefined,
+  }
+
+  const resolutionPattern = (
+    useISOFormat ? resolutionPatternsISO : resolutionPatterns
+  )[resolution]
+
+  return resolutionPattern
+    ? DateTime.fromFormat(
+        dateISOString,
+        `${toUTC ? 'UTC:' : ''}${resolutionPattern}`
+      )
+    : dateISOString.replace(/\.\d{3}/, '')
+}

--- a/src/stores/map.store.model.ts
+++ b/src/stores/map.store.model.ts
@@ -1,6 +1,8 @@
 import type { LayerType, Metadata } from '@/composables/themes/themes.model'
 import { TimeResolution } from '@/services/time.utils'
 
+export const LAYER_CURRENT_TIME_SEPARATOR = '/'
+
 export enum LayerImageType {
   PNG = 'image/png',
   JPG = 'image/jpeg',
@@ -21,9 +23,8 @@ export interface Layer {
   opacity?: number
   previousOpacity?: number
   time?: LayerTime
-  currentTime?: string
-  currentTimeMinDefValue?: string
-  currentTimeMaxDefValue?: string
+  currentTimeMinValue?: string
+  currentTimeMaxValue?: string
 }
 
 export enum LayerTimeMode {
@@ -39,19 +40,13 @@ export enum LayerTimeWidget {
 export interface LayerTime {
   minValue: string
   maxValue: string
-  resolution: TimeResolution
   minDefValue?: string
   maxDefValue?: string
   mode: LayerTimeMode
+  resolution: TimeResolution
   widget: LayerTimeWidget
-}
-
-export type LayerTimeSlider = LayerTime & {
-  values: string[]
-}
-
-export type LayerTimeDatePicker = LayerTime & {
-  interval: number[]
+  values?: string[]
+  interval?: number[]
 }
 
 export interface MapContext {

--- a/src/stores/map.store.model.ts
+++ b/src/stores/map.store.model.ts
@@ -1,4 +1,5 @@
 import type { LayerType, Metadata } from '@/composables/themes/themes.model'
+import { TimeResolution } from '@/services/time.utils'
 
 export enum LayerImageType {
   PNG = 'image/png',
@@ -19,6 +20,38 @@ export interface Layer {
   style?: string
   opacity?: number
   previousOpacity?: number
+  time?: LayerTime
+  currentTime?: string
+  currentTimeMinDefValue?: string
+  currentTimeMaxDefValue?: string
+}
+
+export enum LayerTimeMode {
+  VALUE = 'value',
+  RANGE = 'range',
+}
+
+export enum LayerTimeWidget {
+  DATEPICKER = 'datepicker',
+  SLIDER = 'slider',
+}
+
+export interface LayerTime {
+  minValue: string
+  maxValue: string
+  resolution: TimeResolution
+  minDefValue?: string
+  maxDefValue?: string
+  mode: LayerTimeMode
+  widget: LayerTimeWidget
+}
+
+export type LayerTimeSlider = LayerTime & {
+  values: string[]
+}
+
+export type LayerTimeDatePicker = LayerTime & {
+  interval: number[]
 }
 
 export interface MapContext {

--- a/src/stores/map.store.ts
+++ b/src/stores/map.store.ts
@@ -1,7 +1,8 @@
+import { dateToISOString } from '@/services/time.utils'
 import { defineStore, acceptHMRUpdate } from 'pinia'
 import { ref, Ref, ShallowRef, shallowRef } from 'vue'
 
-import type { LayerId, Layer, MapContext } from './map.store.model'
+import { LayerId, Layer, MapContext } from './map.store.model'
 
 export const useMapStore = defineStore('map', () => {
   const map: Ref<MapContext> = ref({})
@@ -43,6 +44,27 @@ export const useMapStore = defineStore('map', () => {
     })
   }
 
+  function setLayerTime(
+    layerId: LayerId,
+    dateStart?: string,
+    dateEnd?: string
+  ) {
+    layers.value = layers.value.map(elt => {
+      if (elt.id === layerId) {
+        return {
+          ...elt,
+          ...{
+            currentTimeMinValue: dateStart
+              ? dateToISOString(dateStart)
+              : undefined,
+            currentTimeMaxValue: dateEnd ? dateToISOString(dateEnd) : undefined,
+          },
+        }
+      }
+      return elt
+    })
+  }
+
   return {
     map,
     layers,
@@ -51,6 +73,7 @@ export const useMapStore = defineStore('map', () => {
     removeLayers,
     reorderLayers,
     setLayerOpacity,
+    setLayerTime,
     setBgLayer,
     hasLayer,
   }


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-569

### Description

Handle time layers in permalink, plus UI in layer-item. 
There are 4 types of time components : 
- datepicker value, 
- datepicker range, 
- slider value, 
- slider range.

Theme fixtures have been updated with new time layers for tests.
⚠️ Adding time layers on map will be done in another PR.

- new `time` param in permalink (and localstorage)
- add new components `layer-time-datepicker` and `layer-time-slider`
- added new dep `luxon` in package.json to help with date formatting
- fix i18n to find translation when translation key has a `':'`
- fix layer manager accessibility, move bg layer item outside the `ul` list

### Screenshots

#### Slider value
 ![image](https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/assets/115457104/7df0ca18-68c0-45a4-bdb0-1188681925be)

#### Slider range

TODO, in [GSLUX-649](https://jira.camptocamp.com/browse/GSLUX-649)

#### Datepicker range
![image](https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/assets/115457104/0f692000-70bc-47f7-b55d-c7dd7b385851)

#### Datepicker value
![image](https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/assets/115457104/843a3fe0-882f-48ce-a8ed-78fa1cd38760)

### Run in dev

⚠️ There is no update in v3 for now.

👉 If you want to compare behavior in v3 dev mode, please update your db with commit: https://github.com/camptocamp/luxembourg_dev_db/tree/time_layers

