### PR TITLE
Gslux 646 remove ngeo bg manager

### DIFF
--- a/bundle/lux.dist.mjs
+++ b/bundle/lux.dist.mjs
@@ -36485,6 +36485,9 @@ const useMapStore = defineStore("map", () => {
       (layer) => layerIds.indexOf(layer.id) === -1
     );
   }
+  function removeAllLayers() {
+    layers.value = [];
+  }
   function hasLayer(layerId) {
     var _a;
     return !!((_a = layers.value) == null ? void 0 : _a.find((layer) => layer.id === layerId));
@@ -36525,6 +36528,7 @@ const useMapStore = defineStore("map", () => {
     bgLayer,
     addLayers,
     removeLayers,
+    removeAllLayers,
     reorderLayers,
     setLayerOpacity,
     setLayerTime,

--- a/bundle/lux.dist.umd.js
+++ b/bundle/lux.dist.umd.js
@@ -36499,6 +36499,9 @@ This will fail in production.`);
         (layer) => layerIds.indexOf(layer.id) === -1
       );
     }
+    function removeAllLayers() {
+      layers.value = [];
+    }
     function hasLayer(layerId) {
       var _a;
       return !!((_a = layers.value) == null ? void 0 : _a.find((layer) => layer.id === layerId));
@@ -36539,6 +36542,7 @@ This will fail in production.`);
       bgLayer,
       addLayers,
       removeLayers,
+      removeAllLayers,
       reorderLayers,
       setLayerOpacity,
       setLayerTime,

--- a/src/stores/map.store.spec.ts
+++ b/src/stores/map.store.spec.ts
@@ -89,6 +89,14 @@ describe('Map Store', () => {
       expect(mapStore.layers.length).toBe(1)
     })
 
+    it('remove all layers', () => {
+      const mapStore = useMapStore()
+      mapStore.addLayers(layer1, layer2, layer3)
+      expect(mapStore.layers.length).toBe(3)
+      mapStore.removeAllLayers()
+      expect(mapStore.layers.length).toBe(0)
+    })
+
     it('reorder layers', () => {
       const mapStore = useMapStore()
       mapStore.addLayers(layer1, layer2, layer3)

--- a/src/stores/map.store.ts
+++ b/src/stores/map.store.ts
@@ -23,6 +23,10 @@ export const useMapStore = defineStore('map', () => {
     )
   }
 
+  function removeAllLayers() {
+    layers.value = []
+  }
+
   function hasLayer(layerId: LayerId) {
     return !!layers.value?.find(layer => layer.id === layerId)
   }
@@ -71,6 +75,7 @@ export const useMapStore = defineStore('map', () => {
     bgLayer,
     addLayers,
     removeLayers,
+    removeAllLayers,
     reorderLayers,
     setLayerOpacity,
     setLayerTime,


### PR DESCRIPTION
<!-- Title must be: GSLUX-646: Replace ngeoBgMgr by v4 store -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-646

### Description

the function to remove all layers is useful for switching to 3d mesh in v3 (see https://github.com/Geoportail-Luxembourg/geoportailv3/pull/3091 - dev in progress)

### Screenshots

(only if the final render is different)
