### PR TITLE
Gslux 642 3d catalog

### DIFF
--- a/src/assets/ol.css
+++ b/src/assets/ol.css
@@ -52,4 +52,16 @@
     right: 8px;
     border: 1px solid #8394a0;
   }
+
+  .map-3d-button {
+    z-index: 2;
+    bottom: 105px;
+    padding: 0;
+    right: 8px;
+    border: 1px solid #8394a0;
+  }
+  .map-3d-selected button {
+    background-color: brown;
+    color: white;
+  }
 }

--- a/src/components/catalog/catalog-tree.vue
+++ b/src/components/catalog/catalog-tree.vue
@@ -67,7 +67,7 @@ function toggleLayer(node: LayerTreeNodeModel, is3d: boolean) {
 <template>
   <layer-tree-node
     class="mb-6"
-    v-if="layerTree3d"
+    v-if="layerTree3d && mapStore.is_3d_active"
     :node="layerTree3d"
     :key="layerTree3d.id"
     @toggle-parent="node => toggleParent(node, true)"

--- a/src/components/catalog/catalog-tree.vue
+++ b/src/components/catalog/catalog-tree.vue
@@ -37,17 +37,15 @@ function updateLayerTree() {
 }
 
 watchEffect(() => {
-  if (layerTree3d.value) {
+  if (layerTrees_3d.value) {
+    const treeModel = layerTree3d.value
+      ? layerTree3d.value
+      : themesToLayerTree(layerTrees_3d.value)
     layerTree3d.value = layerTreeService.updateLayers(
-      layerTree3d.value,
+      treeModel,
       mapStore.layers_3d
     )
   }
-})
-
-watchEffect(() => {
-  if (!layerTrees_3d.value) return null
-  layerTree3d.value = themesToLayerTree(layerTrees_3d.value)
 })
 
 function toggleParent(node: LayerTreeNodeModel, is3d: boolean) {

--- a/src/components/catalog/catalog-tree.vue
+++ b/src/components/catalog/catalog-tree.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ShallowRef, shallowRef, watchEffect } from 'vue'
+import { storeToRefs } from 'pinia'
 
 import useLayers from '@/composables/layers/layers.composable'
 import { ThemeNodeModel } from '@/composables/themes/themes.model'
@@ -14,6 +15,9 @@ const mapStore = useMapStore()
 const themeStore = useThemeStore()
 const layers = useLayers()
 const layerTree: ShallowRef<LayerTreeNodeModel | undefined> = shallowRef()
+const layerTree3d: ShallowRef<LayerTreeNodeModel | undefined> = shallowRef()
+
+const { layerTrees_3d } = storeToRefs(themeStore)
 
 watchEffect(updateLayerTree)
 
@@ -32,25 +36,48 @@ function updateLayerTree() {
   }
 }
 
-function toggleParent(node: LayerTreeNodeModel) {
-  layerTree.value = layerTreeService.toggleNode(
+watchEffect(() => {
+  if (layerTree3d.value) {
+    layerTree3d.value = layerTreeService.updateLayers(
+      layerTree3d.value,
+      mapStore.layers_3d
+    )
+  }
+})
+
+watchEffect(() => {
+  if (!layerTrees_3d.value) return null
+  layerTree3d.value = themesToLayerTree(layerTrees_3d.value)
+})
+
+function toggleParent(node: LayerTreeNodeModel, is3d: boolean) {
+  const rootTree = is3d ? layerTree3d : layerTree
+  rootTree.value = layerTreeService.toggleNode(
     node.id,
-    layerTree.value as LayerTreeNodeModel,
+    rootTree.value as LayerTreeNodeModel,
     'expanded'
   )
 }
 
-function toggleLayer(node: LayerTreeNodeModel) {
-  layers.toggleLayer(+node.id, !node.checked)
+function toggleLayer(node: LayerTreeNodeModel, is3d: boolean) {
+  layers.toggleLayer(+node.id, !node.checked, is3d)
 }
 </script>
 
 <template>
   <layer-tree-node
+    class="mb-6"
+    v-if="layerTree3d"
+    :node="layerTree3d"
+    :key="layerTree3d.id"
+    @toggle-parent="node => toggleParent(node, true)"
+    @toggle-layer="node => toggleLayer(node, true)"
+  ></layer-tree-node>
+  <layer-tree-node
     v-if="layerTree"
     :node="layerTree"
     :key="layerTree.id"
-    @toggle-parent="toggleParent"
-    @toggle-layer="toggleLayer"
+    @toggle-parent="node => toggleParent(node, false)"
+    @toggle-layer="node => toggleLayer(node, false)"
   ></layer-tree-node>
 </template>

--- a/src/components/catalog/catalog-tree.vue
+++ b/src/components/catalog/catalog-tree.vue
@@ -72,7 +72,7 @@ function toggleLayer(node: LayerTreeNodeModel, is3d: boolean) {
     @toggle-layer="node => toggleLayer(node, true)"
   ></layer-tree-node>
   <layer-tree-node
-    v-if="layerTree"
+    v-if="layerTree && !(mapStore.is_3d_active && mapStore.is_3d_mesh)"
     :node="layerTree"
     :key="layerTree.id"
     @toggle-parent="node => toggleParent(node, false)"

--- a/src/components/layer-manager/layer-item/layer-item.vue
+++ b/src/components/layer-manager/layer-item/layer-item.vue
@@ -8,6 +8,7 @@ import LayerItemSub from './layer-item-sub.vue'
 import LayerTime from '../layer-time/layer-time.vue'
 
 const props = defineProps<{
+  is3d: boolean
   layer: Layer
   draggableClassName: string
   isOpen: boolean
@@ -52,6 +53,7 @@ function changeTime(dateStart?: string, dateEnd?: string) {
   <div class="lux-layer-manager-item relative">
     <div class="w-full flex flex-nowrap items-start gap-x-2">
       <button
+        v-if="!is3d"
         class="fa-solid fa-bars cursor-move mt-1"
         :class="draggableClassName"
         :title="txtDraggableLabel"
@@ -71,6 +73,7 @@ function changeTime(dateStart?: string, dateEnd?: string) {
       >
         <span class="grow">{{ getLabel() }}</span>
         <span
+          v-if="!is3d"
           class="w-3.5 fa-solid"
           :class="isOpen ? 'fa-xmark' : 'fa-ellipsis'"
           aria-hidden="true"
@@ -86,6 +89,7 @@ function changeTime(dateStart?: string, dateEnd?: string) {
 
     <!-- Layer item sub content (opacity and toggle comparator) -->
     <layer-item-sub
+      v-if="!is3d"
       :layer="layer"
       :isOpen="isOpen"
       :isLayerComparatorOpen="isLayerComparatorOpen"

--- a/src/components/layer-manager/layer-manager.vue
+++ b/src/components/layer-manager/layer-manager.vue
@@ -22,7 +22,7 @@ const mapStore = useMapStore()
 const appStore = useAppStore()
 const styles = useMvtStyles()
 const sliderStore = useSliderComparatorStore()
-const { bgLayer } = storeToRefs(mapStore)
+const { layers_3d, bgLayer } = storeToRefs(mapStore)
 const { sliderActive } = storeToRefs(sliderStore)
 
 const layers = computed(() => [...mapStore.layers].reverse())
@@ -81,6 +81,33 @@ function toggleLayerComparator() {
 
 <template>
   <div>
+    <ul class="mb-4" v-if="layers_3d.length > 0">
+      <li
+        v-for="(layer, index) in layers_3d"
+        :key="layer.id"
+        :id="(layer.id as string)"
+        data-cy="myLayer"
+      >
+        <layer-item
+          :is3d="true"
+          :draggableClassName="draggableClassName"
+          :layer="layer"
+          :isOpen="isLayerOpenId === layer.id"
+          :isLayerComparatorOpen="sliderActive"
+          :displayLayerComparatorOpen="index === 0"
+          @clickRemove="removeLayer"
+          @clickToggle="toggleAccordionItem"
+          @clickToggleLayerComparator="toggleLayerComparator"
+          @clickInfo="setMetadataId(layer.id)"
+          @changeOpacity="changeOpacityLayer"
+          @changeTime="
+            (dateStart, dateEnd) => changeTime(layer, dateStart, dateEnd)
+          "
+        >
+        </layer-item>
+      </li>
+    </ul>
+
     <ul id="sortable-layers">
       <li
         v-for="(layer, index) in layers"
@@ -89,6 +116,7 @@ function toggleLayerComparator() {
         data-cy="myLayer"
       >
         <layer-item
+          :is3d="false"
           :draggableClassName="draggableClassName"
           :layer="layer"
           :isOpen="isLayerOpenId === layer.id"

--- a/src/components/map-controls/map-3d.vue
+++ b/src/components/map-controls/map-3d.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useTranslation } from 'i18next-vue'
+import { CLASS_CONTROL, CLASS_UNSELECTABLE } from 'ol/css'
+
+import Control from 'ol/control/Control'
+import useControl from '@/composables/control/control.composable'
+import { onMounted } from 'vue'
+
+import { useMapStore } from '@/stores/map.store'
+
+const mapStore = useMapStore()
+const { t } = useTranslation()
+const props = withDefaults(
+  defineProps<{
+    className?: string
+    label?: string
+    tipLabel?: string
+  }>(),
+  {
+    className: 'map-3d-button',
+    label: '\ue057',
+    tipLabel: '3d',
+  }
+)
+const controlElement = ref(null)
+
+onMounted(() =>
+  useControl(Control, { ...props, ...{ target: controlElement } })
+)
+
+const toggle3d = () => {
+  mapStore.is_3d_active = !mapStore.is_3d_active
+}
+</script>
+
+<template>
+  <div
+    ref="controlElement"
+    :class="`tracker-off ${
+      props.className
+    } ${CLASS_UNSELECTABLE} ${CLASS_CONTROL} ${
+      mapStore.is_3d_active ? 'map-3d-selected' : ''
+    }`"
+  >
+    <button :title="t(props.tipLabel)" @click="toggle3d">
+      {{ props.label }}
+    </button>
+  </div>
+</template>

--- a/src/components/map/map-container.vue
+++ b/src/components/map/map-container.vue
@@ -7,6 +7,7 @@ import { statePersistorMapService } from '@/services/state-persistor/state-persi
 
 import AttributionControl from '../map-controls/attribution-control.vue'
 import LocationControl from '../map-controls/location-control.vue'
+import Map3dControl from '../map-controls/map-3d.vue'
 import FullscreenControl from '../map-controls/fullscreen-control.vue'
 import ZoomControl from '../map-controls/zoom-control.vue'
 import ZoomToExtentControl from '../map-controls/zoom-to-extent-control.vue'
@@ -44,6 +45,7 @@ provide('olMap', olMap)
     <zoom-to-extent-control :extent="DEFAULT_EXTENT" />
     <fullscreen-control />
     <attribution-control />
+    <map-3d-control />
     <location-control />
   </div>
 </template>

--- a/src/composables/layers/layers.composable.ts
+++ b/src/composables/layers/layers.composable.ts
@@ -115,14 +115,15 @@ export default function useLayers() {
     }
   }
 
-  function toggleLayer(id: LayerId, show = true) {
+  function toggleLayer(id: LayerId, show = true, is3d: boolean) {
     const themeStore = useThemeStore()
     const mapStore = useMapStore()
 
     // the cast from ThemeNodeModel | undefined to Layer might not be correct.
     // in the themes fixture only WMS layers correspond to the Layer definition,
     // whereas WMTS layers have "layer" property
-    const layer = <Layer>themes.findById(id, themeStore.theme)
+    const store = is3d ? themeStore.layerTrees_3d : themeStore.theme
+    const layer = <Layer>themes.findById(id, store)
 
     if (layer) {
       const linkedLayers = layer.metadata?.linked_layers || []
@@ -132,7 +133,8 @@ export default function useLayers() {
       } else {
         handleExclusionLayers(layer)
 
-        mapStore.addLayers(
+        const addLayers = is3d ? mapStore.add3dLayers : mapStore.addLayers
+        addLayers(
           initLayer(layer),
           ...linkedLayers.map(layerId =>
             // TODO: not sure if the layer exclusion is working correctly for linked layers?

--- a/src/composables/themes/themes.composable.ts
+++ b/src/composables/themes/themes.composable.ts
@@ -37,6 +37,11 @@ export default function useThemes() {
     }
   }
 
+  function find3dLayerById(id: LayerId) {
+    const { layerTrees_3d } = useThemeStore()
+    return findByIdOrName(id, undefined, layerTrees_3d)
+  }
+
   function findBgLayerById(id: LayerId) {
     const { bgLayers } = useThemeStore()
 
@@ -58,6 +63,7 @@ export default function useThemes() {
   return {
     findById,
     findByName,
+    find3dLayerById,
     findBgLayerById,
     findBgLayerByName,
     setTheme,

--- a/src/services/layer-metadata/layer-metadata.service.ts
+++ b/src/services/layer-metadata/layer-metadata.service.ts
@@ -21,7 +21,9 @@ export class LayerMetadataService {
 
   async getLayerMetadata(id: LayerId, currentLanguage: string) {
     const layer: ThemeNodeModel | undefined =
-      useThemes().findBgLayerById(+id) || useThemes().findById(+id)
+      useThemes().findBgLayerById(+id) ||
+      useThemes().findById(+id) ||
+      useThemes().find3dLayerById(+id)
 
     if (layer) {
       // Internal layer

--- a/src/stores/config.store.ts
+++ b/src/stores/config.store.ts
@@ -13,6 +13,16 @@ export const useThemeStore = defineStore(
       themes.value?.find(theme => theme.name === themeName.value)
     )
     const bgLayers = computed(() => config.value?.background_layers || [])
+    const layerTrees_3d = computed(() => {
+      return {
+        name: 'root_3d',
+        id: -222,
+        children: themes.value
+          ?.filter(theme => theme.metadata?.ol3d_type !== undefined)
+          .map(layer => layer.children[0]),
+        metadata: {},
+      }
+    })
 
     function setThemes(themes: ConfigModel) {
       config.value = themes
@@ -28,6 +38,7 @@ export const useThemeStore = defineStore(
       themeName,
       theme,
       bgLayers,
+      layerTrees_3d,
       setTheme,
       setThemes,
     }

--- a/src/stores/config.store.ts
+++ b/src/stores/config.store.ts
@@ -14,12 +14,14 @@ export const useThemeStore = defineStore(
     )
     const bgLayers = computed(() => config.value?.background_layers || [])
     const layerTrees_3d = computed(() => {
+      const ol3d_groups = themes.value?.filter(
+        theme => theme.metadata?.ol3d_type !== undefined
+      )
+      if (!ol3d_groups) return undefined
       return {
         name: 'root_3d',
         id: -222,
-        children: themes.value
-          ?.filter(theme => theme.metadata?.ol3d_type !== undefined)
-          .map(layer => layer.children[0]),
+        children: ol3d_groups.map(layer => layer.children[0]),
         metadata: {},
       }
     })

--- a/src/stores/config.store.ts
+++ b/src/stores/config.store.ts
@@ -3,6 +3,9 @@ import { computed, ref, shallowRef, ShallowRef } from 'vue'
 
 import { ConfigModel } from '@/composables/themes/themes.model'
 
+const ROOT_NAME_3D = 'root_3d'
+const DUMMY_ID_ROOT_3D = -222
+
 export const useThemeStore = defineStore(
   'config',
   () => {
@@ -19,8 +22,8 @@ export const useThemeStore = defineStore(
       )
       if (!ol3d_groups) return undefined
       return {
-        name: 'root_3d',
-        id: -222,
+        name: ROOT_NAME_3D,
+        id: DUMMY_ID_ROOT_3D,
         children: ol3d_groups.map(layer => layer.children[0]),
         metadata: {},
       }

--- a/src/stores/map.store.ts
+++ b/src/stores/map.store.ts
@@ -7,6 +7,7 @@ import { LayerId, Layer, MapContext } from './map.store.model'
 export const useMapStore = defineStore('map', () => {
   const map: Ref<MapContext> = ref({})
   const layers: ShallowRef<Layer[]> = shallowRef([])
+  const layers_3d: ShallowRef<any[]> = shallowRef([])
   const bgLayer: Ref<Layer | undefined | null> = ref(undefined) // undefined => at start app | null => blank bgLayer
 
   function setBgLayer(layer: Layer | null) {
@@ -17,8 +18,15 @@ export const useMapStore = defineStore('map', () => {
     layers.value = [...new Set([...layers.value, ...newLayers])]
   }
 
+  function add3dLayers(...newLayers: Layer[]) {
+    layers_3d.value = [...new Set([...layers_3d.value, ...newLayers])]
+  }
+
   function removeLayers(...layerIds: LayerId[]) {
     layers.value = layers.value.filter(
+      layer => layerIds.indexOf(layer.id) === -1
+    )
+    layers_3d.value = layers_3d.value.filter(
       layer => layerIds.indexOf(layer.id) === -1
     )
   }
@@ -72,8 +80,10 @@ export const useMapStore = defineStore('map', () => {
   return {
     map,
     layers,
+    layers_3d,
     bgLayer,
     addLayers,
+    add3dLayers,
     removeLayers,
     removeAllLayers,
     reorderLayers,

--- a/src/stores/map.store.ts
+++ b/src/stores/map.store.ts
@@ -9,6 +9,7 @@ export const useMapStore = defineStore('map', () => {
   const layers: ShallowRef<Layer[]> = shallowRef([])
   const layers_3d: ShallowRef<any[]> = shallowRef([])
   const is_3d_active: Ref<boolean> = ref(false)
+  const is_3d_mesh: Ref<boolean> = ref(true)
   const bgLayer: Ref<Layer | undefined | null> = ref(undefined) // undefined => at start app | null => blank bgLayer
 
   function setBgLayer(layer: Layer | null) {
@@ -83,6 +84,7 @@ export const useMapStore = defineStore('map', () => {
     layers,
     layers_3d,
     is_3d_active,
+    is_3d_mesh,
     bgLayer,
     addLayers,
     add3dLayers,

--- a/src/stores/map.store.ts
+++ b/src/stores/map.store.ts
@@ -8,6 +8,7 @@ export const useMapStore = defineStore('map', () => {
   const map: Ref<MapContext> = ref({})
   const layers: ShallowRef<Layer[]> = shallowRef([])
   const layers_3d: ShallowRef<any[]> = shallowRef([])
+  const is_3d_active: Ref<boolean> = ref(false)
   const bgLayer: Ref<Layer | undefined | null> = ref(undefined) // undefined => at start app | null => blank bgLayer
 
   function setBgLayer(layer: Layer | null) {
@@ -81,6 +82,7 @@ export const useMapStore = defineStore('map', () => {
     map,
     layers,
     layers_3d,
+    is_3d_active,
     bgLayer,
     addLayers,
     add3dLayers,


### PR DESCRIPTION
<!-- Title must be: GSLUX-642: 3d in catalog -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-642

### Description

a state has been introduced for 3d mode which can be controlled from v3
3d items can now be displayed in the catalog and in the layer tree.
a dummy button is used for toggling 3d mode in v4

### Screenshots

(only if the final render is different)
