### PR TITLE
trigger auto tag on PR edit and merge

### DIFF
--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,28 +1,31 @@
 name: CI_package
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
   push:
+    branches:
+      - 'main'
     tags:
       - '*'
 jobs:
   tag-version:
-    if: github.event_name == 'pull_request'
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     steps:
       - name: checkout ${{ github.head_ref }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-      - run: git status
-      - run: git rev-parse --abbrev-ref HEAD
+          # default depth is 1, but we need the parent refs
+          fetch-depth: 2
+      - name: compute tag name
+        shell: bash
+        run: |
+          branch=$([[ $(git log --pretty="%p" -n 1 | wc -w) -gt 1 ]] \
+          && echo $(git log -n 1 --pretty="%s" | sed "s|.*Geoportail-Luxembourg/\(.*\)|\1|") \
+          || git branch --show-current)
+          echo $branch
+          echo "AUTO_TAG=${branch}_CI_$(git log -n 1 --pretty=%h)" >> $GITHUB_ENV
       - name: tag ${{ github.head_ref }}
         run: |
-          git tag $(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
+          git tag ${{ env.AUTO_TAG }}
           git push --tags
   lux-package:
     # the combination (if always) + (needs tag-version) makes sure the lux-package job runs

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,9 +1,6 @@
 name: CI_package
 on:
   pull_request:
-    types:
-      - edited
-      - closed
     branches:
       - main
   push:
@@ -16,7 +13,8 @@ jobs:
     steps:
       - name: checkout ${{ github.head_ref }}
         uses: actions/checkout@v4
-        ref: ${{ github.head_ref }}
+        with:
+          ref: ${{ github.head_ref }}
       - run: git status
       - run: git ref-parse --abbrev-ref HEAD
       - name: tag ${{ github.head_ref }}

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - run: git status
       - run: git rev-parse --abbrev-ref HEAD
       - name: tag ${{ github.head_ref }}
@@ -28,7 +29,19 @@ jobs:
     if: ${{ always() }}
     needs: tag-version
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1]', github.head_ref, $GITHUB_SHA) }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: compute tag name
+        run: echo "AUTO_TAG=$(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: check tag name
+        run: |
+          echo ${{ env.AUTO_TAG }}
+          echo ${{ env.TAG }}
       - name: create release
         id: create_release
         uses: octokit/request-action@v2.x
@@ -38,11 +51,7 @@ jobs:
           route: POST /repos/{owner}/{repo}/releases
           owner: 'Geoportail-Luxembourg'
           repo: 'luxembourg-geoportail'
-          tag_name: ${{ github.ref }}
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+          tag_name: ${{ github.event_name == 'push' && github.ref || }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -30,7 +30,7 @@ jobs:
     needs: tag-version
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1]', github.head_ref, github.sha) }}
+      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1}', github.head_ref, github.sha) }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,7 +1,7 @@
 name: CI_package
 on:
   pull_request:
-    type:
+    types:
       - closed
     branches:
       - main

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -16,12 +16,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - run: git status
-      - run: git ref-parse --abbrev-ref HEAD
+      - run: git rev-parse --abbrev-ref HEAD
       - name: tag ${{ github.head_ref }}
         run: |
           # date > generated.txt
           # Note: the following account information will not work on GHES
-          git checkout ${{ github.head_ref }}
           git tag $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
           git push --tags
   lux-package:

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -30,7 +30,7 @@ jobs:
     needs: tag-version
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1]', github.head_ref, GITHUB_SHA) }}
+      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1]', github.head_ref, github.sha) }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -37,7 +37,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: compute tag name
-        run: echo "AUTO_TAG=$(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        shell: bash
+        run: |
+          tt = 1
+          echo $tt
+          at = $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
+          echo "AUTO_TAG=$at" >> $GITHUB_ENV
       - name: check tag name
         run: |
           echo ${{ env.AUTO_TAG }}
@@ -51,7 +56,7 @@ jobs:
           route: POST /repos/{owner}/{repo}/releases
           owner: 'Geoportail-Luxembourg'
           repo: 'luxembourg-geoportail'
-          tag_name: ${{ github.event_name == 'push' && github.ref || }}
+          tag_name: ${{ github.event_name == 'push' && github.ref || env.AUTO_TAG }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,9 +1,6 @@
 name: CI_package
 on:
   pull_request:
-    types:
-      - edited
-      - closed
     branches:
       - master
   push:

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # date > generated.txt
           # Note: the following account information will not work on GHES
-          git tag $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
+          git tag $(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
           git push --tags
   lux-package:
     # if: github.event_name == 'push'
@@ -42,7 +42,7 @@ jobs:
         run: |
           tt=1
           echo $tt
-          at=$(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
+          at=$(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
           echo "AUTO_TAG=$at" >> $GITHUB_ENV
       - name: check tag name
         run: |

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.head_ref }}
           persist-credentials: false
           fetch-depth: 0
       - name: compute tag name

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,6 +1,8 @@
 name: CI_package
 on:
   pull_request:
+    types:
+      - '*'
     branches:
       - main
   push:

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -25,14 +25,15 @@ jobs:
           git tag $(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
           git push --tags
   lux-package:
-    # the combination if always + needs xx makes sure the mackage job runs after completion of the tag job
+    # the combination (if always) + (needs tag-version) makes sure the lux-package job runs
+    # after completion of the tag-version job.
+    # In case of a tag push, the tag-version job is skipped but the lux-package job will run
+    # In case of a closed PR, the tag-version job runs first, the lux-package job runs after completion
     if: ${{ always() }}
     needs: tag-version
     runs-on: ubuntu-latest
-    env:
-      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1}', github.head_ref, github.sha) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           persist-credentials: false

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,8 +1,11 @@
 name: CI_package
 on:
   pull_request:
+    types:
+      - edited
+      - closed
     branches:
-      - master
+      - main
   push:
     tags:
       - '*'

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -2,7 +2,8 @@ name: CI_package
 on:
   pull_request:
     types:
-      - '*'
+      - edited
+      - closed
     branches:
       - main
   push:

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -30,7 +30,7 @@ jobs:
     needs: tag-version
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1]', github.head_ref, $GITHUB_SHA) }}
+      TAG: ${{ github.event_name == 'push' && github.ref || format('{0}_tag_{1]', github.head_ref, GITHUB_SHA) }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,9 +39,9 @@ jobs:
       - name: compute tag name
         shell: bash
         run: |
-          tt = 1
+          tt=1
           echo $tt
-          at = $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
+          at=$(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
           echo "AUTO_TAG=$at" >> $GITHUB_ENV
       - name: check tag name
         run: |

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -39,13 +39,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 2
       - name: compute tag name
         shell: bash
         run: |
-          at=$(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
-          echo "AUTO_TAG=$at" >> $GITHUB_ENV
+          branch=$([[ $(git log --pretty="%p" -n 1 | wc -w) -gt 1 ]] \
+          && echo $(git log -n 1 --pretty="%s" | sed "s|.*Geoportail-Luxembourg/\(.*\)|\1|") \
+          || git branch --show-current)
+          echo $branch
+          echo "AUTO_TAG=${branch}_CI_$(git log -n 1 --pretty=%h)" >> $GITHUB_ENV
       - name: create release
         id: create_release
         uses: octokit/request-action@v2.x
@@ -55,7 +57,7 @@ jobs:
           route: POST /repos/{owner}/{repo}/releases
           owner: 'Geoportail-Luxembourg'
           repo: 'luxembourg-geoportail'
-          tag_name: ${{ github.event_name == 'push' && github.ref || env.AUTO_TAG }}
+          tag_name: ${{ github.ref_type == 'tag' && github.ref || env.AUTO_TAG }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -24,7 +24,9 @@ jobs:
           git tag $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
           git push --tags
   lux-package:
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
+    if: ${{ always() }}
+    needs: tag-version
     runs-on: ubuntu-latest
     steps:
       - name: create release

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,9 +1,6 @@
 name: CI_package
 on:
   pull_request:
-    types:
-      - edited
-      - closed
     branches:
       - main
   push:
@@ -14,7 +11,11 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout ${{ github.head_ref }}
+        uses: actions/checkout@v4
+        ref: ${{ github.head_ref }}
+      - run: git status
+      - run: git ref-parse --abbrev-ref HEAD
       - name: tag ${{ github.head_ref }}
         run: |
           # date > generated.txt

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,10 +1,27 @@
 name: CI_package
 on:
+  pull_request:
+    types:
+      - edited
+      - closed
+    branches:
+      - master
   push:
     tags:
       - '*'
 jobs:
+  tag-version:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          # date > generated.txt
+          # Note: the following account information will not work on GHES
+          git tag $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
+          git push --tags
   lux-package:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: create release

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - main
   push:
     tags:
       - '*'

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -1,6 +1,8 @@
 name: CI_package
 on:
   pull_request:
+    type:
+      - closed
     branches:
       - main
   push:
@@ -20,12 +22,10 @@ jobs:
       - run: git rev-parse --abbrev-ref HEAD
       - name: tag ${{ github.head_ref }}
         run: |
-          # date > generated.txt
-          # Note: the following account information will not work on GHES
           git tag $(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
           git push --tags
   lux-package:
-    # if: github.event_name == 'push'
+    # the combination if always + needs xx makes sure the mackage job runs after completion of the tag job
     if: ${{ always() }}
     needs: tag-version
     runs-on: ubuntu-latest
@@ -40,14 +40,8 @@ jobs:
       - name: compute tag name
         shell: bash
         run: |
-          tt=1
-          echo $tt
           at=$(git rev-parse --abbrev-ref HEAD)_CI_$(git rev-parse --short HEAD)
           echo "AUTO_TAG=$at" >> $GITHUB_ENV
-      - name: check tag name
-        run: |
-          echo ${{ env.AUTO_TAG }}
-          echo ${{ env.TAG }}
       - name: create release
         id: create_release
         uses: octokit/request-action@v2.x

--- a/.github/workflows/ci_bundle.yml
+++ b/.github/workflows/ci_bundle.yml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - name: tag ${{ github.head_ref }}
+        run: |
           # date > generated.txt
           # Note: the following account information will not work on GHES
+          git checkout ${{ github.head_ref }}
           git tag $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
           git push --tags
   lux-package:

--- a/README.md
+++ b/README.md
@@ -97,11 +97,14 @@ The results of the build can be found in the folder `bundle`
 
 An automatic mecanism has been created with github actions. This workflow is triggered when a tag is pushed into the repo.
 
-For the moment there is no automatic tag generation on pull requests, so for dev, the following naming conventions are recommended:
+For dev releases, create a new tag, the CI will then generate the release. The following naming conventions are recommended:
 <branch_name>\_TAG\_<short_commit>
 
+an npm script is included in package.json, so just call
+
 ```
-echo $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
+npm run tag
+git push --tags
 ```
 
 The CI automatically builds the lib, creates a release named after the tag and includes the built bundle in the release. The built package can then be downloaded at the URL:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ This package URL can also be used to reference the dependency for NPM in package
 On merge of a PR on main branch the CI will create an automatic tag of type
 <branch_name>\_CI\_<short_commit>
 
+### Cleanup of tags:
+
+Everyone should clean their own dev-only tags.
+
+The following scripts might come handy to avoid messing up the repo with unused tags.
+
+#### cleaning out local tags before pushing any
+
+Before a git push --tags, one should sync the local tags with the remote ones:
+
+```
+for t in $(git tag -l); do git tag -d $t; done
+git fetch -t
+```
+
+#### cleaning usused tags
+
+there is not any CI automation yet. However, the naming conventio that dev tags shall start with the branch name, makes cleaning them much easier.
+
+```
+for t in $(git tag -l | grep GSLUX-635_automate_tag_on_merge_); do git push origin :refs/tags/$t; done
+```
+
+where `GSLUX-635_automate_tag_on_merge` is the branch name
+
+#### cleaning releases
+
+releases must be deleted manually in the github web interface. The github API might be used, but this can be slightly complex.
+
 ### Import the lib in another app
 
 You can include the built lib multiple ways in the `package.json`:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The results of the build can be found in the folder `bundle`
 An automatic mecanism has been created with github actions. This workflow is triggered when a tag is pushed into the repo.
 
 For the moment there is no automatic tag generation on pull requests, so for dev, the following naming conventions are recommended:
-<branch_name>\_tag\_<short_commit>
+<branch_name>\_TAG\_<short_commit>
 
 ```
 echo $(git rev-parse --abbrev-ref HEAD)_tag_$(git rev-parse --short HEAD)
@@ -111,6 +111,11 @@ The CI automatically builds the lib, creates a release named after the tag and i
 ```
 
 This package URL can also be used to reference the dependency for NPM in package.json, see below
+
+### Automatic tag in CI
+
+On merge of a PR on main branch the CI will create an automatic tag of type
+<branch_name>\_CI\_<short_commit>
 
 ### Import the lib in another app
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The results of the build can be found in the folder `bundle`
 An automatic mecanism has been created with github actions. This workflow is triggered when a tag is pushed into the repo.
 
 For dev releases, create a new tag, the CI will then generate the release. The following naming conventions are recommended:
-<branch_name>\_TAG\_<short_commit>
+<branch_name>\_DEV\_<short_commit>
 
 an npm script is included in package.json, so just call
 
@@ -137,17 +137,18 @@ git fetch -t
 
 #### cleaning usused tags
 
-there is not any CI automation yet. However, the naming conventio that dev tags shall start with the branch name, makes cleaning them much easier.
+There is not any CI automation yet for cleaning tags. However, the naming convention (dev tags shall start with the branch name) makes cleaning them much easier.
 
 ```
 for t in $(git tag -l | grep GSLUX-635_automate_tag_on_merge_); do git push origin :refs/tags/$t; done
+for t in $(git tag -l | grep GSLUX-635_automate_tag_on_merge_); do git tag -d $t; done
 ```
 
 where `GSLUX-635_automate_tag_on_merge` is the branch name
 
 #### cleaning releases
 
-releases must be deleted manually in the github web interface. The github API might be used, but this can be slightly complex.
+Releases must be deleted manually in the github web interface. The github API might be used, but this would be some extra complexity for the moment.
 
 ### Import the lib in another app
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-dev",
   "private": true,
   "scripts": {
+    "tag": "git tag $(git rev-parse --abbrev-ref HEAD)_TAG_$(git rev-parse --short HEAD)",
     "start": "npm run dev",
     "dev": "vite --force",
     "build": "run-p type-check build-only",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-dev",
   "private": true,
   "scripts": {
-    "tag": "git tag $(git rev-parse --abbrev-ref HEAD)_TAG_$(git rev-parse --short HEAD)",
+    "tag": "git tag $(git rev-parse --abbrev-ref HEAD)_DEV_$(git rev-parse --short HEAD)",
     "start": "npm run dev",
     "dev": "vite --force",
     "build": "run-p type-check build-only",


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-635

### Description

automatic tag generation on PRs

the workflow was tested with the sub PR below:
https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/132
this created correctly the release https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/tag/GSLUX-635_automate_tag_on_merge_test_merge_CI_8e1839f

the manual workflow (npm run tag) was tested with this release:
https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/tag/GSLUX-635_automate_tag_on_merge_TAG_c1576cd

checks:

- [x] manual
- [x] auto

### Screenshots

(only if the final render is different)
