### PR TITLE
GSLUX-743: Modify circle geometries

### DIFF
--- a/cypress/e2e/draw/draw-feat-circle.cy.ts
+++ b/cypress/e2e/draw/draw-feat-circle.cy.ts
@@ -26,6 +26,24 @@ describe('Draw "Circle"', () => {
       testFeatItemMeasurements()
     })
 
+    it('updates length, area and radius measurements when editing geometry on map', () => {
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '346.59 km')
+      cy.get('*[data-cy="featItemArea"]').should('contain.text', '9559.11 km²')
+      cy.get('*[data-cy="featItemInputRadius"]').should(
+        'have.value',
+        '55161.21'
+      )
+      cy.dragVertexOnMap(200, 200, 300, 300)
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '693.17 km')
+      cy.get('*[data-cy="featItemArea"]').should('contain.text', '38235.40 km²')
+    })
+
+    it('updates length and area measurements when editing radius in panel', () => {
+      cy.get('*[data-cy="featItemInputRadius"]').type('{selectall}1000{enter}')
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '6.28 km')
+      cy.get('*[data-cy="featItemArea"]').should('contain.text', '3.13 km²')
+    })
+
     it('displays the possible actions for the feature', () => {
       testFeatItem()
     })

--- a/cypress/e2e/draw/draw-feat-line.cy.ts
+++ b/cypress/e2e/draw/draw-feat-line.cy.ts
@@ -28,9 +28,9 @@ describe('Draw "Line"', () => {
     })
 
     it('updates length measurement when editing geometry', () => {
-      cy.get('*[data-cy="featItemLength"]').should('contain.text', '55.4 km')
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '55.36 km')
       cy.dragVertexOnMap(200, 200, 300, 300)
-      cy.get('*[data-cy="featItemLength"]').should('contain.text', '111 km')
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '111.14 km')
     })
 
     it('displays the possible actions for the feature', () => {

--- a/cypress/e2e/draw/draw-feat-polygon.cy.ts
+++ b/cypress/e2e/draw/draw-feat-polygon.cy.ts
@@ -28,11 +28,11 @@ describe('Draw "Polygon"', () => {
     })
 
     it('updates length and area measurements when editing geometry', () => {
-      cy.get('*[data-cy="featItemLength"]').should('contain.text', '134 km')
-      cy.get('*[data-cy="featItemArea"]').should('contain.text', '766 km²')
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '133.81 km')
+      cy.get('*[data-cy="featItemArea"]').should('contain.text', '766.33 km²')
       cy.dragVertexOnMap(200, 200, 300, 300)
-      cy.get('*[data-cy="featItemLength"]').should('contain.text', '238 km')
-      cy.get('*[data-cy="featItemArea"]').should('contain.text', '1530 km²')
+      cy.get('*[data-cy="featItemLength"]').should('contain.text', '238.47 km')
+      cy.get('*[data-cy="featItemArea"]').should('contain.text', '1532.65 km²')
     })
 
     it('displays the possible actions for the feature', () => {

--- a/src/bundle/lib.ts
+++ b/src/bundle/lib.ts
@@ -49,7 +49,8 @@ import { clearLayersCache } from '@/stores/layers.cache'
 import i18next, { InitOptions } from 'i18next'
 import backend from 'i18next-http-backend'
 import I18NextVue from 'i18next-vue'
-import formatDistanceDirective from '@/directives/format-distance.directive'
+import formatLengthDirective from '@/directives/format-length.directive'
+import formatAreaDirective from '@/directives/format-area.directive'
 
 import App from '../App.vue'
 
@@ -79,7 +80,8 @@ export default function useLuxLib(options: LuxLibOptions) {
   app.use(createPinia())
   app.use(I18NextVue, { i18next })
   app.use(VueDOMPurifyHTML)
-  app.use(formatDistanceDirective)
+  app.use(formatLengthDirective)
+  app.use(formatAreaDirective)
 
   const createElementInstance = (component = {}, app = null) => {
     return defineCustomElement(

--- a/src/components/draw/feature-measurements.vue
+++ b/src/components/draw/feature-measurements.vue
@@ -116,6 +116,7 @@ function onClickValidateRadius(radius: string) {
       <!-- Radius is editable when edition mode is on -->
       <div v-else class="flex">
         <input
+          data-cy="featItemInputRadius"
           class="form-control block"
           type="text"
           v-model="inputRadius"

--- a/src/components/draw/feature-measurements.vue
+++ b/src/components/draw/feature-measurements.vue
@@ -6,6 +6,8 @@ import { DrawnFeature } from '@/services/draw/drawn-feature'
 import FeatureMeasurementsProfile from './feature-measurements-profile.vue'
 import {
   getFormattedArea,
+  getFormattedCircleArea,
+  getFormattedCircleLength,
   getFormattedLength,
 } from '@/services/common/measurement.utils'
 import { Circle, Geometry, Point, Polygon } from 'ol/geom'
@@ -28,19 +30,33 @@ const feature = ref<DrawnFeature | undefined>(inject('feature'))
 const featureType = ref<string>(feature.value?.featureType || '')
 const featureGeometry = ref<Geometry | undefined>(feature.value?.getGeometry())
 
-//TODO: update for circle
-const featLength = computed(() =>
-  featureGeometry.value &&
-  ['drawnLine', 'drawnPolygon'].includes(featureType.value)
-    ? getFormattedLength(featureGeometry.value as Geometry, mapProjection)
-    : undefined
-)
-//TODO: update for circle
-const featArea = computed(() =>
-  featureGeometry.value && ['drawnPolygon'].includes(featureType.value)
-    ? getFormattedArea(featureGeometry.value as Polygon)
-    : undefined
-)
+const featLength = computed(() => {
+  if (featureGeometry.value) {
+    if (['drawnLine', 'drawnPolygon'].includes(featureType.value)) {
+      return getFormattedLength(
+        featureGeometry.value as Geometry,
+        mapProjection
+      )
+    } else if (featureType.value === 'drawnCircle') {
+      return getFormattedCircleLength(featureGeometry.value as Circle)
+    } else {
+      return undefined
+    }
+  }
+  return undefined
+})
+const featArea = computed(() => {
+  if (featureGeometry.value) {
+    if (featureType.value === 'drawnPolygon') {
+      return getFormattedArea(featureGeometry.value as Polygon)
+    } else if (featureType.value === 'drawnCircle') {
+      return getFormattedCircleArea(featureGeometry.value as Circle)
+    } else {
+      return undefined
+    }
+  }
+  return undefined
+})
 const featRadius = computed(() =>
   featureGeometry.value && featureType.value === 'drawnCircle'
     ? (featureGeometry.value as Circle).getRadius().toFixed(2)

--- a/src/components/draw/feature-measurements.vue
+++ b/src/components/draw/feature-measurements.vue
@@ -8,6 +8,7 @@ import {
   getArea,
   getCircleArea,
   getCircleLength,
+  getCircleRadius,
   getLength,
 } from '@/services/common/measurement.utils'
 import { Circle, Geometry, Point, Polygon } from 'ol/geom'
@@ -35,7 +36,7 @@ const featLength = computed(() => {
     if (['drawnLine', 'drawnPolygon'].includes(featureType.value)) {
       return getLength(featureGeometry.value as Geometry, mapProjection)
     } else if (featureType.value === 'drawnCircle') {
-      return getCircleLength(featureGeometry.value as Circle)
+      return getCircleLength(featureGeometry.value as Circle, mapProjection)
     } else {
       return undefined
     }
@@ -47,7 +48,7 @@ const featArea = computed(() => {
     if (featureType.value === 'drawnPolygon') {
       return getArea(featureGeometry.value as Polygon)
     } else if (featureType.value === 'drawnCircle') {
-      return getCircleArea(featureGeometry.value as Circle)
+      return getCircleArea(featureGeometry.value as Circle, mapProjection)
     } else {
       return undefined
     }
@@ -56,9 +57,8 @@ const featArea = computed(() => {
 })
 const featRadius = computed(() =>
   featureGeometry.value && featureType.value === 'drawnCircle'
-    ? (featureGeometry.value as Circle).getRadius()
-    : // ? getCircleRadius(featureGeometry.value as Circle, mapProjection)
-      undefined
+    ? getCircleRadius(featureGeometry.value as Circle, mapProjection)
+    : undefined
 )
 const inputRadius = ref<string>(featRadius.value?.toString() || '')
 
@@ -80,12 +80,10 @@ watchEffect(async () => {
 watchEffect(() => {
   inputRadius.value =
     featureType.value === 'drawnCircle'
-      ? (featureGeometry.value as Circle).getRadius().toFixed(2)
+      ? getCircleRadius(featureGeometry.value as Circle, mapProjection).toFixed(
+          2
+        )
       : ''
-  // inputRadius.value = getCircleRadius(
-  //   featureGeometry.value as Circle,
-  //   mapProjection
-  // )
 })
 
 function onClickValidateRadius(radius: string) {

--- a/src/components/draw/feature-measurements.vue
+++ b/src/components/draw/feature-measurements.vue
@@ -37,8 +37,6 @@ const featLength = computed(() => {
       return getLength(featureGeometry.value as Geometry, mapProjection)
     } else if (featureType.value === 'drawnCircle') {
       return getCircleLength(featureGeometry.value as Circle, mapProjection)
-    } else {
-      return undefined
     }
   }
   return undefined
@@ -49,8 +47,6 @@ const featArea = computed(() => {
       return getArea(featureGeometry.value as Polygon)
     } else if (featureType.value === 'drawnCircle') {
       return getCircleArea(featureGeometry.value as Circle, mapProjection)
-    } else {
-      return undefined
     }
   }
   return undefined
@@ -60,7 +56,7 @@ const featRadius = computed(() =>
     ? getCircleRadius(featureGeometry.value as Circle, mapProjection)
     : undefined
 )
-const inputRadius = ref<string>(featRadius.value?.toString() || '')
+const inputRadius = ref<number>(featRadius.value || 0)
 
 const featElevation = ref<number | undefined>()
 
@@ -80,13 +76,16 @@ watchEffect(async () => {
 watchEffect(() => {
   inputRadius.value =
     featureType.value === 'drawnCircle'
-      ? getCircleRadius(featureGeometry.value as Circle, mapProjection).toFixed(
-          2
+      ? parseFloat(
+          getCircleRadius(
+            featureGeometry.value as Circle,
+            mapProjection
+          ).toFixed(2)
         )
-      : ''
+      : 0
 })
 
-function onClickValidateRadius(radius: string) {
+function onClickValidateRadius(radius: number) {
   if (feature.value) {
     useEdit().setRadius(feature.value as DrawnFeature, Number(radius))
   }
@@ -117,8 +116,8 @@ function onClickValidateRadius(radius: string) {
       <div v-else class="flex">
         <input
           data-cy="featItemInputRadius"
-          class="form-control block"
-          type="text"
+          class="form-control block bg-secondary text-white border !border-gray-300"
+          type="number"
           v-model="inputRadius"
           @keyup.enter="onClickValidateRadius(inputRadius)"
         />

--- a/src/composables/draw/draw-tooltip.ts
+++ b/src/composables/draw/draw-tooltip.ts
@@ -6,8 +6,7 @@ import { Circle, Geometry, LineString, Polygon } from 'ol/geom'
 import OlMap from 'ol/Map'
 import { DrawEvent } from 'ol/interaction/Draw'
 import { getLength, getArea } from '@/services/common/measurement.utils'
-import { formatLength } from '@/directives/format-length.directive'
-import { formatArea } from '@/directives/format-area.directive'
+import { formatLength, formatArea } from '@/services/common/formatting.utils'
 
 class DrawTooltip {
   private measureTooltipElement: HTMLElement | null = null

--- a/src/composables/draw/draw-tooltip.ts
+++ b/src/composables/draw/draw-tooltip.ts
@@ -5,10 +5,9 @@ import { unByKey } from 'ol/Observable'
 import { Circle, Geometry, LineString, Polygon } from 'ol/geom'
 import OlMap from 'ol/Map'
 import { DrawEvent } from 'ol/interaction/Draw'
-import {
-  getFormattedLength,
-  getFormattedArea,
-} from '@/services/common/measurement.utils'
+import { getLength, getArea } from '@/services/common/measurement.utils'
+import { formatLength } from '@/directives/format-length.directive'
+import { formatArea } from '@/directives/format-area.directive'
 
 class DrawTooltip {
   private measureTooltipElement: HTMLElement | null = null
@@ -69,7 +68,7 @@ class DrawTooltip {
       const geom = geometry as LineString
       coord = geom.getLastCoordinate()
       if (coord !== null) {
-        output = getFormattedLength(geom, proj)
+        output = formatLength(getLength(geom, proj))
       }
     } else if (geometry.getType() === 'Polygon') {
       const geom = geometry as Polygon
@@ -78,14 +77,14 @@ class DrawTooltip {
         coord = geom.getInteriorPoint().getCoordinates()
       }
       if (coord !== null) {
-        output = getFormattedArea(geom)
+        output = formatArea(getArea(geom))
       }
     } else if (geometry.getType() === 'Circle') {
       const geom = geometry as Circle
       coord = geom.getLastCoordinate()
       const center = geom.getCenter()
       if (center !== null && coord !== null) {
-        output = getFormattedLength(new LineString([center, coord]), proj)
+        output = formatLength(getLength(new LineString([center, coord]), proj))
       }
     }
     if (this.measureTooltipElement) {

--- a/src/composables/draw/draw-utils.ts
+++ b/src/composables/draw/draw-utils.ts
@@ -1,6 +1,8 @@
-import { Circle, Geometry } from 'ol/geom'
-import { fromCircle } from 'ol/geom/Polygon'
-import { Feature } from 'ol'
+import { Circle } from 'ol/geom'
+import Polygon, { fromCircle } from 'ol/geom/Polygon'
+import { getDistance } from 'ol/sphere'
+import { toLonLat } from 'ol/proj'
+import { DrawnFeature } from '@/services/draw/drawn-feature'
 
 // TODO 3D
 // import { transform } from 'ol/proj'
@@ -9,14 +11,34 @@ import { Feature } from 'ol'
 // TODO 3D
 // const ARROW_MODEL_URL = import.meta.env.VITE_ARROW_MODEL_URL
 
-function convertCircleToPolygon(
-  feature: Feature<Geometry>,
-  featureType: String
-) {
+function convertCircleFeatureToPolygon(feature: DrawnFeature): DrawnFeature {
   const geom = feature.getGeometry()
-  if (featureType == 'drawnCircle' && geom?.getType() == 'Circle') {
+  if (feature.featureType == 'drawnCircle' && geom?.getType() == 'Circle') {
     feature.setGeometry(fromCircle(geom as Circle, 64))
   }
+  return feature
 }
 
-export { convertCircleToPolygon }
+function convertPolygonFeatureToCircle(feature: DrawnFeature): DrawnFeature {
+  const polygon = feature.getGeometry() as Polygon
+  if (
+    feature.featureType === 'drawnCircle' &&
+    polygon?.getType() === 'Polygon'
+  ) {
+    const extent = polygon.getExtent()
+    const centroid = [(extent[0] + extent[2]) / 2, (extent[1] + extent[3]) / 2]
+    const coordinates = polygon.getCoordinates()[0]
+    let maxDistance = 0
+    coordinates.forEach(coord => {
+      const distance = getDistance(toLonLat(centroid), toLonLat(coord))
+      if (distance > maxDistance) {
+        maxDistance = distance
+      }
+    })
+    const circle = new Circle(centroid, maxDistance)
+    feature.setGeometry(circle as Circle)
+  }
+  return feature
+}
+
+export { convertCircleFeatureToPolygon, convertPolygonFeatureToCircle }

--- a/src/composables/draw/draw-utils.ts
+++ b/src/composables/draw/draw-utils.ts
@@ -3,6 +3,9 @@ import Polygon, { fromCircle } from 'ol/geom/Polygon'
 import { getDistance } from 'ol/sphere'
 import { toLonLat } from 'ol/proj'
 import { DrawnFeature } from '@/services/draw/drawn-feature'
+import { setCircleRadius } from '@/services/common/measurement.utils'
+import useMap from '../map/map.composable'
+import { Map } from 'ol'
 
 // TODO 3D
 // import { transform } from 'ol/proj'
@@ -20,6 +23,7 @@ function convertCircleFeatureToPolygon(feature: DrawnFeature): DrawnFeature {
 }
 
 function convertPolygonFeatureToCircle(feature: DrawnFeature): DrawnFeature {
+  const map: Map = useMap().getOlMap()
   const polygon = feature.getGeometry() as Polygon
   if (
     feature.featureType === 'drawnCircle' &&
@@ -35,7 +39,8 @@ function convertPolygonFeatureToCircle(feature: DrawnFeature): DrawnFeature {
         maxDistance = distance
       }
     })
-    const circle = new Circle(centroid, maxDistance)
+    const circle = new Circle(centroid)
+    setCircleRadius(circle, maxDistance, map)
     feature.setGeometry(circle as Circle)
   }
   return feature

--- a/src/composables/draw/draw-utils.ts
+++ b/src/composables/draw/draw-utils.ts
@@ -14,13 +14,26 @@ import { Map } from 'ol'
 // TODO 3D
 // const ARROW_MODEL_URL = import.meta.env.VITE_ARROW_MODEL_URL
 
+/**
+ * Note that feature.featureType and geom?.getType() values mostly correspond to each other.
+ * One exception are 'drawnCircle' featureTypes that are managed as 'Polygon' geometries within the URL and during export.
+ * (Another exception are 'drawnLabel' featureTypes that are managed as 'Point' geometries throughout the application.)
+ * @param feature Feature with a circle geometry
+ * @returns The same feature with a polygon geometry
+ */
 function convertCircleFeatureToPolygon(feature: DrawnFeature): DrawnFeature {
   const geom = feature.getGeometry()
-  if (feature.featureType == 'drawnCircle' && geom?.getType() == 'Circle') {
+  if (feature.featureType === 'drawnCircle' && geom?.getType() === 'Circle') {
     feature.setGeometry(fromCircle(geom as Circle, 64))
   }
   return feature
 }
+
+/**
+ *
+ * @param feature Feature with a polygon geometry
+ * @returns The same feature with a circle geometry
+ */
 
 function convertPolygonFeatureToCircle(feature: DrawnFeature): DrawnFeature {
   const map: Map = useMap().getOlMap()

--- a/src/composables/draw/drawn-features.composable.ts
+++ b/src/composables/draw/drawn-features.composable.ts
@@ -4,7 +4,6 @@ import { Feature } from 'ol'
 import { Point, Circle, Geometry, LineString } from 'ol/geom'
 import Polygon from 'ol/geom/Polygon'
 import { useDrawStore } from '@/stores/draw.store'
-import { convertCircleToPolygon } from '@/composables/draw/draw-utils'
 import { useAppStore } from '@/stores/app.store'
 import { screenSizeIsAtLeast } from '@/services/common/device.utils'
 
@@ -64,7 +63,6 @@ export default function useDrawnFeatures() {
       featureType,
       featureStyle,
     })
-    convertCircleToPolygon(drawnFeature, featureType)
 
     addDrawnFeature(drawnFeature)
 

--- a/src/composables/draw/edit.composable.ts
+++ b/src/composables/draw/edit.composable.ts
@@ -12,6 +12,7 @@ import useMap from '../map/map.composable'
 import { EditStateActive } from '@/stores/draw.store.model'
 import { DEFAULT_DRAW_ZINDEX, FEATURE_LAYER_TYPE } from './draw.composable'
 import { Circle } from 'ol/geom'
+import { setCircleRadius } from '@/services/common/measurement.utils'
 
 export default function useEdit() {
   const { editStateActive, editingFeatureId, drawnFeatures } = storeToRefs(
@@ -86,7 +87,7 @@ export default function useEdit() {
   function setRadius(feature: DrawnFeature, radius: number) {
     const geometry = feature.getGeometry()
     if (geometry?.getType() === 'Circle') {
-      ;(geometry as Circle).setRadius(radius)
+      setCircleRadius(geometry as Circle, radius, map)
       updateDrawnFeature(feature)
     }
   }

--- a/src/composables/draw/edit.composable.ts
+++ b/src/composables/draw/edit.composable.ts
@@ -11,6 +11,7 @@ import { useDrawStore } from '@/stores/draw.store'
 import useMap from '../map/map.composable'
 import { EditStateActive } from '@/stores/draw.store.model'
 import { DEFAULT_DRAW_ZINDEX, FEATURE_LAYER_TYPE } from './draw.composable'
+import { Circle } from 'ol/geom'
 
 export default function useEdit() {
   const { editStateActive, editingFeatureId, drawnFeatures } = storeToRefs(
@@ -80,5 +81,17 @@ export default function useEdit() {
       const feature = (event as ModifyEvent).features.getArray()[0]
       updateDrawnFeature(feature as DrawnFeature)
     })
+  }
+
+  function setRadius(feature: DrawnFeature, radius: number) {
+    const geometry = feature.getGeometry()
+    if (geometry?.getType() === 'Circle') {
+      ;(geometry as Circle).setRadius(radius)
+      updateDrawnFeature(feature)
+    }
+  }
+
+  return {
+    setRadius,
   }
 }

--- a/src/directives/format-area.directive.ts
+++ b/src/directives/format-area.directive.ts
@@ -1,4 +1,4 @@
-import i18next from 'i18next'
+import { formatArea } from '@/services/common/formatting.utils'
 import { App } from 'vue'
 
 export default {
@@ -18,16 +18,4 @@ function format(el: HTMLElement, value: number): void {
   let formattedText: string = ''
   formattedText = formatArea(value)
   el.textContent = formattedText
-}
-
-export function formatArea(value: number): string {
-  if (value === null) {
-    return i18next.t('N/A', { ns: 'client' })
-  } else if (value < 1000000) {
-    return `${value.toFixed(2)} m²`
-  } else if (value >= 1000000) {
-    return `${(value / 1000000).toFixed(2)} km²`
-  } else {
-    return ''
-  }
 }

--- a/src/directives/format-area.directive.ts
+++ b/src/directives/format-area.directive.ts
@@ -1,0 +1,33 @@
+import i18next from 'i18next'
+import { App } from 'vue'
+
+export default {
+  install(app: App) {
+    app.directive('format-area', {
+      beforeMount(el: HTMLElement, binding: { value: number }) {
+        format(el, binding.value)
+      },
+      updated(el: HTMLElement, binding: { value: number }) {
+        format(el, binding.value)
+      },
+    })
+  },
+}
+
+function format(el: HTMLElement, value: number): void {
+  let formattedText: string = ''
+  formattedText = formatArea(value)
+  el.textContent = formattedText
+}
+
+export function formatArea(value: number): string {
+  if (value === null) {
+    return i18next.t('N/A', { ns: 'client' })
+  } else if (value < 1000000) {
+    return `${value.toFixed(2)} m²`
+  } else if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(2)} km²`
+  } else {
+    return ''
+  }
+}

--- a/src/directives/format-length.directive.ts
+++ b/src/directives/format-length.directive.ts
@@ -1,4 +1,4 @@
-import i18next from 'i18next'
+import { formatLength } from '@/services/common/formatting.utils'
 import { App } from 'vue'
 
 export default {
@@ -18,17 +18,4 @@ function format(el: HTMLElement, value: number): void {
   let formattedText: string = ''
   formattedText = formatLength(value)
   el.textContent = formattedText
-}
-
-export function formatLength(value: number): string {
-  //null covers API errors or unaivalble data (eg. elevation)
-  if (value === null) {
-    return i18next.t('N/A', { ns: 'client' })
-  } else if (value < 1000) {
-    return `${value.toFixed(2)} m`
-  } else if (value >= 1000) {
-    return `${(value / 1000).toFixed(2)} km`
-  } else {
-    return ''
-  }
 }

--- a/src/directives/format-length.directive.ts
+++ b/src/directives/format-length.directive.ts
@@ -3,7 +3,7 @@ import { App } from 'vue'
 
 export default {
   install(app: App) {
-    app.directive('format-distance', {
+    app.directive('format-length', {
       beforeMount(el: HTMLElement, binding: { value: number }) {
         format(el, binding.value)
       },
@@ -16,12 +16,19 @@ export default {
 
 function format(el: HTMLElement, value: number): void {
   let formattedText: string = ''
-  if (value === null) {
-    formattedText = i18next.t('N/A', { ns: 'client' })
-  } else if (value < 1000) {
-    formattedText = `${value.toFixed(2)} m`
-  } else if (value >= 1000) {
-    formattedText = `${(value / 1000).toFixed(2)} km`
-  }
+  formattedText = formatLength(value)
   el.textContent = formattedText
+}
+
+export function formatLength(value: number): string {
+  //null covers API errors or unaivalble data (eg. elevation)
+  if (value === null) {
+    return i18next.t('N/A', { ns: 'client' })
+  } else if (value < 1000) {
+    return `${value.toFixed(2)} m`
+  } else if (value >= 1000) {
+    return `${(value / 1000).toFixed(2)} km`
+  } else {
+    return ''
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ import { createPinia } from 'pinia'
 import { initProjections } from '@/services/projection.utils'
 import { useThemeStore } from './stores/config.store'
 import { themesApiFixture } from './__fixtures__/themes.api.fixture'
-import formatDistanceDirective from '@/directives/format-distance.directive'
+import formatLengthDirective from '@/directives/format-length.directive'
+import formatAreaDirective from '@/directives/format-area.directive'
 
 import App from './App.vue'
 
@@ -38,7 +39,8 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(I18NextVue, { i18next })
 app.use(VueDOMPurifyHTML)
-app.use(formatDistanceDirective)
+app.use(formatLengthDirective)
+app.use(formatAreaDirective)
 
 app.mount('#app')
 

--- a/src/services/common/formatting.utils.ts
+++ b/src/services/common/formatting.utils.ts
@@ -1,4 +1,37 @@
+import i18next from 'i18next'
+
+/**
+ * Note: Formatting utils can be used via directives in HTML templates.
+ * v-format-length="value"
+ * v-format-area="value"
+ */
+
 export function formatDate(dateString: string, language: string = 'fr-FR') {
   const date = new Date(dateString)
   return new Intl.DateTimeFormat(language).format(date)
+}
+
+export function formatLength(value: number): string {
+  //null covers API errors or unavailable data (eg. elevation)
+  if (value === null) {
+    return i18next.t('N/A', { ns: 'client' })
+  } else if (value < 1000) {
+    return `${value.toFixed(2)} m`
+  } else if (value >= 1000) {
+    return `${(value / 1000).toFixed(2)} km`
+  } else {
+    return ''
+  }
+}
+
+export function formatArea(value: number): string {
+  if (value === null) {
+    return i18next.t('N/A', { ns: 'client' })
+  } else if (value < 1000000) {
+    return `${value.toFixed(2)} m²`
+  } else if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(2)} km²`
+  } else {
+    return ''
+  }
 }

--- a/src/services/common/measurement.utils.ts
+++ b/src/services/common/measurement.utils.ts
@@ -1,4 +1,4 @@
-import { formatLength } from '@/directives/format-length.directive'
+import { formatLength } from './formatting.utils'
 import { Coordinate } from 'ol/coordinate'
 import { LineString, Polygon, Point, Geometry, Circle } from 'ol/geom'
 import {
@@ -12,6 +12,7 @@ import {
   getArea as getOlArea,
 } from 'ol/sphere'
 import { Map } from 'ol'
+import { PROJECTION_WGS84 } from '@/composables/map/map.composable'
 
 const getLength = function (geom: Geometry, projection: Projection): number {
   let length = 0
@@ -22,8 +23,8 @@ const getLength = function (geom: Geometry, projection: Projection): number {
     coordinates = (geom as LineString).getCoordinates() as Coordinate[]
   }
   for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-    const c1 = transform(coordinates[i], projection, 'EPSG:4326')
-    const c2 = transform(coordinates[i + 1], projection, 'EPSG:4326')
+    const c1 = transform(coordinates[i], projection, PROJECTION_WGS84)
+    const c2 = transform(coordinates[i + 1], projection, PROJECTION_WGS84)
     length += haversineDistance(c1, c2)
   }
   return length

--- a/src/services/common/measurement.utils.ts
+++ b/src/services/common/measurement.utils.ts
@@ -22,6 +22,33 @@ const getFormattedLength = function (
     const c2 = transform(coordinates[i + 1], projection, 'EPSG:4326')
     length += haversineDistance(c1, c2)
   }
+  return formatLength(length, precision || 3)
+}
+
+const getFormattedArea = function (
+  polygon: Polygon,
+  precision?: number
+): string {
+  const area = Math.abs(getArea(polygon))
+  return formatArea(area, precision || 3)
+}
+
+//TODO: handle projection ?
+const getFormattedCircleLength = function (
+  circle: Circle,
+  precision?: number
+): string {
+  const radius = circle.getRadius()
+  const length = 2 * Math.PI * radius
+  return formatLength(length, precision || 3)
+}
+
+const getFormattedCircleArea = function (circle: Circle, precision?: number) {
+  const area = Math.PI * Math.pow(circle.getRadius(), 2)
+  return formatArea(area, precision || 3)
+}
+
+function formatLength(length: number, precision: number): string {
   let output
   if (length > 1000) {
     output =
@@ -32,22 +59,15 @@ const getFormattedLength = function (
   return output
 }
 
-const getFormattedArea = function (polygon: Polygon): string {
-  const area = Math.abs(getArea(polygon))
+function formatArea(area: number, precision: number) {
   let output = ''
   if (area > 1000000) {
-    output = parseFloat((area / 1000000).toPrecision(3)) + ' ' + 'km²'
+    output = parseFloat((area / 1000000).toPrecision(precision)) + ' ' + 'km²'
   } else {
-    output = parseFloat(area.toPrecision(3)) + ' ' + 'm²'
+    output = parseFloat(area.toPrecision(precision)) + ' ' + 'm²'
   }
   return output
 }
-
-// TODO: migrate and use once circle is kept as a circle geometry
-// const getFormattedCircleArea = function (circle, precision, format) {
-//   const area = Math.PI * Math.pow(circle.getRadius(), 2)
-//   return format(area, 'm²', 'square', precision)
-// }
 
 const getCircleRadius = function (circle: Circle, proj: Projection): string {
   const coord = circle.getLastCoordinate()
@@ -95,5 +115,7 @@ export {
   getFormattedArea,
   getFormattedAzimutRadius,
   getFormattedPoint,
+  getFormattedCircleLength,
+  getFormattedCircleArea,
   getCircleRadius,
 }

--- a/src/services/common/measurement.utils.ts
+++ b/src/services/common/measurement.utils.ts
@@ -1,5 +1,5 @@
 import { Coordinate } from 'ol/coordinate'
-import { LineString, Polygon, Point, Geometry } from 'ol/geom'
+import { LineString, Polygon, Point, Geometry, Circle } from 'ol/geom'
 import { Projection, transform } from 'ol/proj'
 import { getDistance as haversineDistance, getArea } from 'ol/sphere'
 
@@ -49,14 +49,13 @@ const getFormattedArea = function (polygon: Polygon): string {
 //   return format(area, 'm²', 'square', precision)
 // }
 
-// TODO: migrate and use once circle is kept as a circle geometry
-// const getCircleRadius = function (circle: Circle, proj: Projection): string {
-//   const coord = circle.getLastCoordinate()
-//   const center = circle.getCenter()
-//   return center !== null && coord !== null
-//     ? getFormattedLength(new LineString([center, coord]), proj)
-//     : ''
-// }
+const getCircleRadius = function (circle: Circle, proj: Projection): string {
+  const coord = circle.getLastCoordinate()
+  const center = circle.getCenter()
+  return center !== null && coord !== null
+    ? getFormattedLength(new LineString([center, coord]), proj)
+    : ''
+}
 
 const getFormattedAzimutRadius = function (
   line: LineString,
@@ -96,4 +95,5 @@ export {
   getFormattedArea,
   getFormattedAzimutRadius,
   getFormattedPoint,
+  getCircleRadius,
 }

--- a/src/services/draw/drawn-feature.ts
+++ b/src/services/draw/drawn-feature.ts
@@ -31,6 +31,25 @@ export class DrawnFeature extends Feature {
   featureStyle: DrawnFeatureStyle
   map = useMap().getOlMap()
 
+  constructor(drawnFeature?: DrawnFeature) {
+    if (drawnFeature) {
+      super(drawnFeature.getGeometry())
+      this.label = drawnFeature.label
+      this.featureType = drawnFeature.featureType
+      this.map_id = drawnFeature.map_id
+      this.description = drawnFeature.description
+      this.display_order = drawnFeature.display_order
+      this.editable = drawnFeature.editable
+      this.selected = drawnFeature.selected
+      this.featureStyle = drawnFeature.featureStyle
+      this.id = drawnFeature.id
+      this.saving = drawnFeature.saving
+      this.setProperties(drawnFeature.getProperties())
+    } else {
+      super()
+    }
+  }
+
   fit() {
     const size = this.map.getSize()
     const extent = <Extent>this.getGeometry()?.getExtent()

--- a/src/services/export-feature/export-feature.ts
+++ b/src/services/export-feature/export-feature.ts
@@ -4,6 +4,8 @@ import { Geometry, GeometryCollection, MultiLineString } from 'ol/geom'
 
 import { PROJECTION_WGS84 } from '@/composables/map/map.composable'
 import { downloadFile, sanitizeFilename } from '@/services/utils'
+import { convertCircleFeatureToPolygon } from '@/composables/draw/draw-utils'
+import { DrawnFeature } from '../draw/drawn-feature'
 
 export abstract class ExportFeature {
   encodeOptions: { dataProjection: string; featureProjection: Projection }
@@ -59,6 +61,11 @@ export abstract class ExportFeature {
           linestrings.forEach(geom =>
             explodedFeatures.push(this.cloneFeatureWithGeom(feature, geom))
           )
+          break
+        }
+        case 'Circle': {
+          const newFeature = new DrawnFeature(feature as DrawnFeature)
+          explodedFeatures.push(convertCircleFeatureToPolygon(newFeature))
           break
         }
         default:

--- a/src/services/state-persistor/state-persistor-features.mapper.ts
+++ b/src/services/state-persistor/state-persistor-features.mapper.ts
@@ -1,11 +1,26 @@
+import {
+  convertCircleFeatureToPolygon,
+  convertPolygonFeatureToCircle,
+} from '@/composables/draw/draw-utils'
 import featureHash from './utils/FeatureHash'
 import { DrawnFeature } from '@/services/draw/drawn-feature'
 
+/**
+ * Note that the mapper converts circles to polygons and back to circles.
+ * This allows one single ol modify interaction to edit all types of geometries
+ * and keeps them encoded as polygons in the URL (as in v3).
+ * It is important that persist creates seperate feature instances to get rid of the reference to the ol feature
+ */
 class StorageFeaturesMapper {
   featuresToUrl(features: DrawnFeature[] | null): string {
     if (!features) return ''
-    const featuresToEncode = features.filter(feature => !feature.map_id)
-    featuresToEncode.forEach(f => f.set('name', f.label))
+    const featuresToEncode = features
+      .filter(feature => !feature.map_id)
+      .map(feature => {
+        const newFeature = new DrawnFeature(feature) //create new instance to avoid converting ol feature to polygon
+        // newFeature.set('name', newFeature.label) //is this still needed?
+        return convertCircleFeatureToPolygon(newFeature)
+      })
     return featuresToEncode.length > 0
       ? featureHash.writeFeatures(featuresToEncode)
       : ''
@@ -13,9 +28,9 @@ class StorageFeaturesMapper {
 
   urlToFeatures(url: string | null): DrawnFeature[] {
     const features = url ? featureHash.readFeatures(url) : []
-    const drawnFeatures = features.map((f, i) =>
-      featureHash.decodeShortProperties(f, i)
-    )
+    const drawnFeatures = features
+      .map((feature, i) => featureHash.decodeShortProperties(feature, i))
+      .map(feature => convertPolygonFeatureToCircle(feature))
     return drawnFeatures
   }
 }

--- a/src/services/state-persistor/utils/FeatureHash.ts
+++ b/src/services/state-persistor/utils/FeatureHash.ts
@@ -36,7 +36,6 @@ import Fill from 'ol/style/Fill'
 import Style from 'ol/style/Style'
 import { DrawnFeature } from '@/services/draw/drawn-feature'
 import { DrawnFeatureStyle } from '@/stores/draw.store.model'
-import { convertCircleToPolygon } from '@/composables/draw/draw-utils'
 
 const GeometryTypeValues = {
   LineString: 'LineString',
@@ -306,7 +305,6 @@ class FeatureHash extends TextFeature {
         featureStyle: drawnFeatureStyle,
       }
     )
-    convertCircleToPolygon(drawnFeature, featureType)
     return drawnFeature
 
     // TODO check defaults:

--- a/src/services/state-persistor/utils/FeatureStyleHelper.ts
+++ b/src/services/state-persistor/utils/FeatureStyleHelper.ts
@@ -27,8 +27,7 @@ import {
   getFormattedAzimutRadius,
   getFormattedPoint,
 } from '@/services/common/measurement.utils'
-import { formatLength } from '@/directives/format-length.directive'
-import { formatArea } from '@/directives/format-area.directive'
+import { formatLength, formatArea } from '@/services/common/formatting.utils'
 
 const styleGeometryType = {
   CIRCLE: 'Circle',
@@ -634,10 +633,10 @@ class FeatureStyleHelper {
           this.decimals_
         )
       } else {
-        measure = formatArea(getArea(geometry)) //, this.projection_, this.precision_, this.unitPrefixFormat_);
+        measure = formatArea(getArea(geometry))
       }
     } else if (geometry instanceof olGeomLineString) {
-      measure = formatLength(getLength(geometry, this.projection_!)) //, this.precision_, this.unitPrefixFormat_);
+      measure = formatLength(getLength(geometry, this.projection_!))
     } else if (geometry instanceof olGeomPoint) {
       if (this.pointFilterFn_ === null) {
         measure = getFormattedPoint(geometry, this.decimals_)

--- a/src/services/state-persistor/utils/FeatureStyleHelper.ts
+++ b/src/services/state-persistor/utils/FeatureStyleHelper.ts
@@ -22,11 +22,13 @@ import olStyleStyle from 'ol/style/Style'
 import olStyleText from 'ol/style/Text'
 import * as olProj from 'ol/proj'
 import {
-  getFormattedLength,
-  getFormattedArea,
+  getLength,
+  getArea,
   getFormattedAzimutRadius,
   getFormattedPoint,
 } from '@/services/common/measurement.utils'
+import { formatLength } from '@/directives/format-length.directive'
+import { formatArea } from '@/directives/format-area.directive'
 
 const styleGeometryType = {
   CIRCLE: 'Circle',
@@ -250,7 +252,7 @@ class FeatureStyleHelper {
       if (showMeasure && azimut !== undefined) {
         // Radius style:
         const line = this.getRadiusLine(feature, azimut)
-        const length = getFormattedLength(line, this.projection_!) //, this.precision_, this.unitPrefixFormat_);
+        const length = formatLength(getLength(line, this.projection_!)) //, this.precision_, this.unitPrefixFormat_);
 
         styles.push(
           new olStyleStyle({
@@ -629,14 +631,13 @@ class FeatureStyleHelper {
         measure = getFormattedAzimutRadius(
           line,
           this.projection_!,
-          this.decimals_,
-          this.precision_ || 3
+          this.decimals_
         )
       } else {
-        measure = getFormattedArea(geometry) //, this.projection_, this.precision_, this.unitPrefixFormat_);
+        measure = formatArea(getArea(geometry)) //, this.projection_, this.precision_, this.unitPrefixFormat_);
       }
     } else if (geometry instanceof olGeomLineString) {
-      measure = getFormattedLength(geometry, this.projection_!) //, this.precision_, this.unitPrefixFormat_);
+      measure = formatLength(getLength(geometry, this.projection_!)) //, this.precision_, this.unitPrefixFormat_);
     } else if (geometry instanceof olGeomPoint) {
       if (this.pointFilterFn_ === null) {
         measure = getFormattedPoint(geometry, this.decimals_)

--- a/src/stores/draw.store.ts
+++ b/src/stores/draw.store.ts
@@ -76,6 +76,7 @@ export const useDrawStore = defineStore('draw', () => {
     drawnFeatures.value = drawnFeatures.value.filter(
       feature => feature.id !== featureId
     )
+    editingFeatureId.value = undefined
   }
 
   return {


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-743

### Description

PR enables editing circle geometries and calculates circle measurements. It refactors the measurement formatting further into directives. Note that vertices are not highlighted anymore like in v3, but the default ol modification style is applied.

There is one remaining issue regarding the circle radius which is not an exact value. Due to `resolutionFactor` applied before `circle.setRadius()` it is approximate and decreases on multiple submits or app reloads:
- submitted values in the radius input are also approximate on prod
- submitting same values multiple times also has an issue on prod
- reloading the app on prod may work because encoded polygon geometries are not converted back to circles

I didn't manage to fix this issue (which is partially also present on prod) within `setCircleRadius` and propose to create a separate ticket for this:

Available options to solve this could be to:
- find a solution in `get/setCircleRadius` (not sure if possible)
- handle circle geometries as polygons and introduce a separate modify interaction for them as in v3
- encode circle geometries as circles in URL

To-dos:

- [x] check area, length calculation
- [x] fix issue with (circle radius) measurements, not calculating correct values
- [x] display circle radius unit outside of input / continue to refactor formatting to directive
- [x] tests
- [x] check/fix exports
