### PR TITLE
GSLUX-766: Do not init useDraw in v3

### DIFF
--- a/src/components/map/map-container.vue
+++ b/src/components/map/map-container.vue
@@ -15,6 +15,7 @@ import FullscreenControl from '../map-controls/fullscreen-control.vue'
 import ZoomControl from '../map-controls/zoom-control.vue'
 import ZoomToExtentControl from '../map-controls/zoom-to-extent-control.vue'
 import useDraw from '@/composables/draw/draw.composable'
+import useDrawSelect from '@/composables/draw/draw-select.composable'
 
 const appStore = useAppStore()
 const { embedded } = storeToRefs(appStore)
@@ -36,6 +37,8 @@ const props = withDefaults(
 if (props.v4_standalone) {
   const draw = useDraw()
   draw.addDrawLayer(olMap)
+  // initialise map listeners for feature selection
+  useDrawSelect()
 }
 
 const DEFAULT_EXTENT = [

--- a/src/components/map/map-container.vue
+++ b/src/components/map/map-container.vue
@@ -21,11 +21,8 @@ const { embedded } = storeToRefs(appStore)
 const map = useMap()
 const mapContainer = ref(null)
 const olMap = map.createMap()
-// add draw layer after map init to allow restoring draw features
-const draw = useDraw()
-draw.addDrawLayer(olMap)
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     v4_standalone?: boolean
   }>(),
@@ -33,6 +30,13 @@ withDefaults(
     v4_standalone: false,
   }
 )
+
+// add draw layer after map init to allow restoring draw features (not in v3 for now)
+// TODO: remove v4_standalone condition once v4 draw is used in v3
+if (props.v4_standalone) {
+  const draw = useDraw()
+  draw.addDrawLayer(olMap)
+}
 
 const DEFAULT_EXTENT = [
   425152.9429259216, 6324465.99999133, 914349.9239510496, 6507914.867875754,

--- a/src/services/state-persistor/state-persistor-features.service.ts
+++ b/src/services/state-persistor/state-persistor-features.service.ts
@@ -5,7 +5,6 @@ import { storageHelper } from './storage/storage.helper'
 import { storageFeaturesMapper } from './state-persistor-features.mapper'
 import { useDrawStore } from '@/stores/draw.store'
 import { DrawnFeature } from '@/services/draw/drawn-feature'
-import useDrawSelect from '@/composables/draw/draw-select.composable'
 
 class StatePersistorFeaturesService implements StatePersistorService {
   bootstrap() {
@@ -36,8 +35,6 @@ class StatePersistorFeaturesService implements StatePersistorService {
 
   restore() {
     const { drawnFeatures } = storeToRefs(useDrawStore())
-    // initialise map listeners for feature selection
-    useDrawSelect()
 
     const features = storageHelper.getValue(
       SP_KEY_FEATURES,


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-766

### Description

PR adds a condition to init v4 draw logic only in v4 and not v3 (where it has not been integrated yet).

This caused a bug when deleting drawn features when using permalinks.