### PR TITLE
GSLUX-756: Migrate feature info templates

### DIFF
--- a/src/components/info/feature-info.vue
+++ b/src/components/info/feature-info.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { defineProps, onUnmounted } from 'vue'
-import DefaultTemplate from '@/components/info/templates/default-template.vue'
-import LignesBusTemplate from './templates/lignes-bus-template.vue'
 import {
   FeatureInfoJSON,
   FeatureJSON,
@@ -16,6 +14,13 @@ import { Feature } from 'ol'
 import { Geometry } from 'ol/geom'
 import GeoJSON from 'ol/format/GeoJSON'
 import useMap, { PROJECTION_LUX } from '@/composables/map/map.composable'
+import DefaultTemplate from './templates/default-template.vue'
+import LignesBusTemplate from './templates/lignes-bus-template.vue'
+import AdresseTemplate from './templates/adresse-template.vue'
+import AeroTemplate from './templates/aero-template.vue'
+import AffairesTemplate from './templates/affaires-template.vue'
+import AstaTemplate from './templates/asta-template.vue'
+import AutomaticSolsTemplate from './templates/automatic-sols-template.vue'
 
 defineProps({
   content: {
@@ -32,6 +37,11 @@ onUnmounted(() => {
 
 const templates = {
   'default.html': DefaultTemplate,
+  'adresse.html': AdresseTemplate,
+  'aero.html': AeroTemplate,
+  'affaires.html': AffairesTemplate,
+  'asta_esp.html': AstaTemplate,
+  'automatic_sols.html': AutomaticSolsTemplate,
   'lignes_bus.html': LignesBusTemplate,
 }
 

--- a/src/components/info/feature-info.vue
+++ b/src/components/info/feature-info.vue
@@ -23,6 +23,7 @@ defineProps({
     required: true,
   },
 })
+const currentUrl = window.location.href
 const map = useMap().getOlMap()
 
 onUnmounted(() => {
@@ -82,6 +83,7 @@ function onExport(payload: { feature: FeatureJSON; format: ExportFormat }) {
       :key="index"
       :is="getTemplateComponent(layers.template)"
       :layers="layers"
+      :currentUrl="currentUrl"
       @export="onExport"
     />
   </div>

--- a/src/components/info/feature-info.vue
+++ b/src/components/info/feature-info.vue
@@ -30,15 +30,13 @@ onUnmounted(() => {
   featureInfoLayerService.clearFeatures()
 })
 
+const templates = {
+  'default.html': DefaultTemplate,
+  'lignes_bus.html': LignesBusTemplate,
+}
+
 const getTemplateComponent = (template: string) => {
-  switch (template) {
-    case 'default.html':
-      return DefaultTemplate
-    case 'lignes_bus.html':
-      return LignesBusTemplate
-    default:
-      return DefaultTemplate
-  }
+  return templates[template as keyof typeof templates] || DefaultTemplate
 }
 
 function onExport(payload: { feature: FeatureJSON; format: ExportFormat }) {

--- a/src/components/info/templates/adresse-template.vue
+++ b/src/components/info/templates/adresse-template.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { FeatureInfoJSON } from '@/services/info/feature-info.model'
+import { useTranslation } from 'i18next-vue'
+defineProps({
+  layers: {
+    type: Object as () => FeatureInfoJSON,
+    required: true,
+  },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
+})
+defineEmits<{
+  (e: 'export'): void
+}>()
+const { t } = useTranslation()
+</script>
+<template>
+  <h1 class="lux-poi-title">{{ t(layers.layerLabel) }}</h1>
+  <div
+    v-for="feature in layers.features"
+    :key="feature.id"
+    class="lux-feature-info"
+  >
+    <h4>{{ feature.attributes.num_affaire }}</h4>
+    {{ feature.attributes.numero }}, {{ feature.attributes.rue }}<br />
+    L-{{ feature.attributes.code_postal }} {{ feature.attributes.localite
+    }}<br />
+    <a
+      class="fid-link no-print"
+      :href="currentUrl + '&fid=' + feature.fid"
+      target="_blank"
+    >
+      {{ t('Lien direct vers cet objet') }}</a
+    ><br />
+  </div>
+</template>

--- a/src/components/info/templates/aero-template.vue
+++ b/src/components/info/templates/aero-template.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { FeatureInfoJSON } from '@/services/info/feature-info.model'
+import { useTranslation } from 'i18next-vue'
+defineProps({
+  layers: {
+    type: Object as () => FeatureInfoJSON,
+    required: true,
+  },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
+})
+defineEmits<{
+  (e: 'export'): void
+}>()
+const { t } = useTranslation()
+</script>
+<template>
+  <h1 class="lux-poi-title">{{ t(layers.layerLabel) }}</h1>
+  <div
+    v-for="feature in layers.features"
+    :key="feature.id"
+    class="lux-feature-info"
+  >
+    <h3>{{ feature.attributes.name }}</h3>
+    <a :href="feature.attributes.path as string" target="_blank">
+      <img
+        v-if="feature.attributes.thumbnail_path"
+        :src="feature.attributes.thumbnail_path as string"
+        alt="thumbnail"
+        width="250"
+      />
+    </a>
+    <span class="no-print">{{ t("Cliquez dans l'image pour agrandir") }}</span
+    ><br />
+    <a
+      class="fid-link no-print"
+      :href="currentUrl + '&fid=' + feature.fid"
+      target="_blank"
+    >
+      {{ t('Lien direct vers cet objet') }}</a
+    ><br />
+  </div>
+</template>

--- a/src/components/info/templates/affaires-template.vue
+++ b/src/components/info/templates/affaires-template.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { FeatureInfoJSON } from '@/services/info/feature-info.model'
+import { useTranslation } from 'i18next-vue'
+defineProps({
+  layers: {
+    type: Object as () => FeatureInfoJSON,
+    required: true,
+  },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
+})
+defineEmits<{
+  (e: 'export'): void
+}>()
+const { t } = useTranslation()
+</script>
+<template>
+  <h1 class="lux-poi-title">{{ t(layers.layerLabel) }}</h1>
+  <div
+    v-for="feature in layers.features"
+    :key="feature.id"
+    class="lux-feature-info"
+  >
+    <h4>{{ feature.attributes.num_affaire }}</h4>
+    {{ feature.attributes.numero }}, {{ feature.attributes.rue }}<br />
+    L-{{ feature.attributes.code_postal }} {{ feature.attributes.localite
+    }}<br />
+    <span> {{ t('Numero') }}</span> : {{ feature.attributes.num_affaire }}<br />
+    <span> {{ t('Numero cadastral') }} </span> : {{ feature.attributes.label
+    }}<br />
+    <span>{{ t('Geometre') }}</span> : {{ feature.attributes.geometre }}<br />
+    <span>{{ t('Region') }}</span> : {{ feature.attributes.region }}<br />
+    <span>{{ t('Type') }}</span> : {{ t(feature.attributes.type as string)
+    }}<br />
+    <span>{{ t('Statut') }}</span> : {{ t(feature.attributes.statut as string)
+    }}<br />
+    <span>{{ t('Date') }}</span> : {{ feature.attributes.date }}<br />
+    <a
+      class="fid-link no-print"
+      :href="currentUrl + '&fid=' + feature.fid"
+      target="_blank"
+    >
+      {{ t('Lien direct vers cet objet') }}</a
+    ><br />
+  </div>
+</template>

--- a/src/components/info/templates/asta-template.vue
+++ b/src/components/info/templates/asta-template.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { FeatureInfoJSON } from '@/services/info/feature-info.model'
+import { useTranslation } from 'i18next-vue'
+defineProps({
+  layers: {
+    type: Object as () => FeatureInfoJSON,
+    required: true,
+  },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
+})
+defineEmits<{
+  (e: 'export'): void
+}>()
+const { t } = useTranslation()
+</script>
+<template>
+  <h1 class="lux-poi-title">{{ t(layers.layerLabel) }}</h1>
+  <div
+    v-for="feature in layers.features"
+    :key="feature.id"
+    class="lux-feature-info"
+  >
+    <span>{{ t('Numero EFA') }}</span> : {{ feature.attributes.code_elem
+    }}{{ feature.attributes.efa }}<br />
+    <div v-if="feature.attributes.surface">
+      <span>{{ t('Surface') }}</span> :
+      {{ Number(feature.attributes.surface).toFixed(1) }} a<br />
+    </div>
+    <div v-if="feature.attributes.longueur">
+      <span>{{ t('Longueur') }}</span> :
+      <span v-format-measure:1.length="feature.attributes.longueur"></span>
+      <br />
+    </div>
+    <a
+      class="fid-link no-print"
+      :href="currentUrl + '&fid=' + feature.fid"
+      target="_blank"
+    >
+      {{ t('Lien direct vers cet objet') }}</a
+    ><br />
+  </div>
+</template>

--- a/src/components/info/templates/automatic-sols-template.vue
+++ b/src/components/info/templates/automatic-sols-template.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import {
+  FeatureInfoJSON,
+  FeatureJSON,
+} from '@/services/info/feature-info.model'
+import { useTranslation } from 'i18next-vue'
+import {
+  hasAttributes,
+  hasValidFID,
+  isEmptyString,
+  isLink,
+  sortedAttributeEntries,
+} from './template-utilities'
+import i18next from 'i18next'
+import ProfileFeatureInfo from '@/components/info/profile-feature-info.vue'
+
+defineProps({
+  layers: {
+    type: Object as () => FeatureInfoJSON,
+    required: true,
+  },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
+})
+defineEmits<{
+  (e: 'export', payload: { feature: FeatureJSON; format: 'kml' | 'gpx' }): void
+}>()
+const { t } = useTranslation()
+</script>
+<template>
+  <div class="flex flex-col">
+    <div>
+      <h1 class="lux-poi-title">
+        {{ t(layers.layerLabel) }}
+      </h1>
+      <div
+        v-for="feature in layers.features"
+        :key="feature.id"
+        class="lux-feature-info"
+      >
+        <h4 v-if="feature.attributes.label">
+          {{ t(feature.attributes.label) }}
+        </h4>
+        <div data-cy="defaultTemplateAttributes" v-if="hasAttributes(feature)">
+          <div
+            v-for="attributeEntry in sortedAttributeEntries(
+              feature.attributes,
+              layers.ordered
+            )"
+            :key="attributeEntry.key"
+          >
+            <span
+              v-if="
+                !isEmptyString(attributeEntry.value) &&
+                !attributeEntry.key.startsWith('f_LC_class_name') &&
+                !attributeEntry.key.startsWith('f_LABEL_')
+              "
+            >
+              <label v-if="!isLink(attributeEntry.value)"
+                >{{ t(attributeEntry.key) }} :
+              </label>
+              <span
+                v-if="!isLink(attributeEntry.value)"
+                v-dompurify-html="attributeEntry.value"
+              ></span>
+              <a
+                v-if="isLink(attributeEntry.value)"
+                :href="attributeEntry.value"
+                target="_blank"
+                >{{ t(attributeEntry.key) }}</a
+              >
+            </span>
+            <span
+              v-if="
+                !isEmptyString(attributeEntry.value) &&
+                (attributeEntry.key.startsWith('f_LC_class_name') ||
+                  attributeEntry.key.startsWith('f_LABEL_'))
+              "
+            >
+              <label
+                v-if="
+                  i18next.language == 'fr' &&
+                  (attributeEntry.key == 'f_LC_class_name_fr' ||
+                    attributeEntry.key == 'f_LABEL_fr')
+                "
+                >{{ t(attributeEntry.key) }} :
+              </label>
+              <span
+                v-if="
+                  i18next.language == 'fr' &&
+                  (attributeEntry.key == 'f_LC_class_name_fr' ||
+                    attributeEntry.key == 'f_LABEL_fr')
+                "
+                v-dompurify-html="attributeEntry.value"
+              ></span>
+              <label
+                v-if="
+                  (i18next.language == 'de' || i18next.language == 'lb') &&
+                  (attributeEntry.key == 'f_LC_class_name_de' ||
+                    attributeEntry.key == 'f_LABEL_de')
+                "
+                >{{ t(attributeEntry.key) }} :
+              </label>
+              <span
+                v-if="
+                  (i18next.language == 'de' || i18next.language == 'lb') &&
+                  (attributeEntry.key == 'f_LC_class_name_de' ||
+                    attributeEntry.key == 'f_LABEL_de')
+                "
+                v-dompurify-html="attributeEntry.value"
+              ></span>
+              <label
+                v-if="
+                  i18next.language == 'en' &&
+                  (attributeEntry.key == 'f_LC_class_name' ||
+                    attributeEntry.key == 'f_LABEL_eng')
+                "
+                >{{ t(attributeEntry.key) }} :
+              </label>
+              <span
+                v-if="
+                  i18next.language == 'en' &&
+                  (attributeEntry.key == 'f_LC_class_name' ||
+                    attributeEntry.key == 'f_LABEL_eng')
+                "
+                v-dompurify-html="attributeEntry.value"
+              ></span>
+            </span>
+          </div>
+        </div>
+        <div class="query-profile" v-if="layers.has_profile">
+          <profile-feature-info :feature="feature" />
+        </div>
+        <div v-if="layers.has_profile">
+          <button
+            class="lux-feature-info-export"
+            @click="$emit('export', { feature, format: 'kml' })"
+          >
+            {{ t('Exporter KMl') }}
+          </button>
+          <button
+            class="lux-feature-info-export"
+            @click="$emit('export', { feature, format: 'gpx' })"
+          >
+            {{ t('Exporter GPX') }}
+          </button>
+        </div>
+
+        <div v-if="!hasAttributes(feature)">
+          <span>{{
+            t('Aucune information disponible pour cette couche')
+          }}</span>
+        </div>
+        <div v-if="hasValidFID(feature)">
+          <span
+            ><a
+              data-cy="defaultTemplateLink"
+              :href="currentUrl + '&fid=' + feature.fid"
+              target="_blank"
+              >{{ t('Lien direct vers cet objet') }}</a
+            ></span
+          >
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/info/templates/default-template.vue
+++ b/src/components/info/templates/default-template.vue
@@ -23,12 +23,15 @@ defineProps({
     type: Object as () => FeatureInfoJSON,
     required: true,
   },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
 })
 defineEmits<{
   (e: 'export', payload: { feature: FeatureJSON; format: 'kml' | 'gpx' }): void
 }>()
 const { t } = useTranslation()
-const currentUrl = window.location.href
 
 function isNoSolarNorWaterLink(label: string, attributeEntry: AttributeEntry) {
   return (

--- a/src/components/info/templates/lignes-bus-template.vue
+++ b/src/components/info/templates/lignes-bus-template.vue
@@ -6,6 +6,10 @@ defineProps({
     type: Object as () => FeatureInfoJSON,
     required: true,
   },
+  currentUrl: {
+    type: String,
+    required: false,
+  },
 })
 </script>
 <template>

--- a/src/services/info/feature-info.model.ts
+++ b/src/services/info/feature-info.model.ts
@@ -20,6 +20,7 @@ export interface Attributes {
   showProfile: { active: boolean }
   profile: any
   label: string
+  [key: string]: unknown
 }
 
 export interface FeatureInfoJSON {


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-756

### Description

This PR migrates the templates for the feature info.

| template  | layer(s) to test | migrated | tested manually | e2e |comments |
| ------------- | ------------- |------------- | ------------- |------------- | ------------- | 
| adresse  | 152  | yes | yes | no |
| aero  | 140  | yes | yes | no |
| affaires  | 362  | yes | no | no | restricted access, wasn't able to access locally
| anf_amphibiens_sauvetage_live  | 2292  | no | no | no | no features found yet
| asta_esp  | 139  | yes | yes | no |
| automatic_sols  | 1950  | yes | yes | no |