### PR TITLE
Stay in the theme when disconnected even if the theme does not exist …

### DIFF
--- a/src/stores/config.store.ts
+++ b/src/stores/config.store.ts
@@ -35,20 +35,10 @@ export const useThemeStore = defineStore(
 
     function setThemes(themes: ConfigModel) {
       config.value = themes
-
-      // Force reset current theme, eg. if theme was restricted,
-      // may not exists anymore when user disconnect
-      if (theme.value === undefined) {
-        resetCurrentTheme()
-      }
     }
 
     function setTheme(name: string) {
       themeName.value = name
-    }
-
-    function resetCurrentTheme() {
-      themeName.value = DEFAULT_CURRENT_THEME
     }
 
     return {


### PR DESCRIPTION
Some users are coming into prof map using a google search, and they don't want to be redirected to the main theme even if they are not connected

![image](https://github.com/user-attachments/assets/7ce08977-49a9-4508-ba75-3e3344fb4e2e)


