### PR TITLE
GITLAB-32 : hides the component instead of recreating it

### DIFF
--- a/src/components/layer-panel/layer-panel.vue
+++ b/src/components/layer-panel/layer-panel.vue
@@ -69,10 +69,12 @@ function onDisplayCatalog() {
     <template v-slot:content>
       <layer-manager
         data-cy="myLayers"
-        v-if="showMyLayersTab"
+        v-show="showMyLayersTab"
         @display-catalog="onDisplayCatalog"
       ></layer-manager>
-      <catalog-tab v-if="!showMyLayersTab"></catalog-tab>
+      <div v-show="!showMyLayersTab">
+        <catalog-tab></catalog-tab>
+      </div>
     </template>
   </side-panel-layout>
 </template>


### PR DESCRIPTION
### GITLAB  issue

https://gitlab.geoportail.lu/cadastre_intern/mapv3/-/issues/32

### Description

Hides the component instead of recreating it.
That means, we can now switch from catalog to layer tab without loosing the opened categories.

