### PR TITLE
GITLAB-32: As we use v-show instead of v-if the dom element always exists

### DIFF
--- a/src/components/layer-panel/layer-panel.spec.ts
+++ b/src/components/layer-panel/layer-panel.spec.ts
@@ -23,12 +23,12 @@ describe('LayerPanel', () => {
     const appStore = useAppStore()
 
     expect(wrapper.findComponent(CatalogTab).exists()).toBe(true)
-    expect(wrapper.findComponent(LayerManager).exists()).toBe(false)
+    expect(wrapper.findComponent(LayerManager).exists()).toBe(true)
 
     appStore.setMyLayersTabOpen(true)
     await wrapper.vm.$nextTick() // "Wait for the DOM to update before continuing the test"
 
     expect(wrapper.findComponent(CatalogTab).exists()).toBe(true)
-    expect(wrapper.findComponent(LayerManager).exists()).toBe(false)
+    expect(wrapper.findComponent(LayerManager).exists()).toBe(true)
   })
 })


### PR DESCRIPTION
### GITLAB issue

https://gitlab.geoportail.lu/cadastre_intern/mapv3/-/issues/32

