### PR TITLE
GSLUX-810: Keep same ground position in center as in 2d

### DIFF
--- a/cypress/e2e/3d-viewer/link-to-3d-viewer.cy.ts
+++ b/cypress/e2e/3d-viewer/link-to-3d-viewer.cy.ts
@@ -18,7 +18,7 @@ describe('Link to 3D Viewer', () => {
         .should(
           'have.attr',
           'href',
-          'https://3d.geoportail.lu/?state=%5B%5B%5B6.000000496232584%2C49.69999815293053%2C350000%5D%2C%5B6.000000496232584%2C49.69999815293053%2C350000%5D%2C300%2C-90%2C-30%2C0%5D%2C%22cesium%22%2C%5B%22catalogConfig%22%2C%22LuxConfig%22%5D%2C%5B%5B%22basemap_2015_global%22%2C1%2C0%5D%2C%5B%22communes_labels%22%2C1%2C0%5D%2C%5B%22country%22%2C1%2C0%5D%2C%5B%22cantons%22%2C1%2C0%5D%5D%2C%5B%5D%2C0%5D'
+          'https://3d.geoportail.lu/?state=%5B%5B%5B%5D%2C%5B6.000000496232584%2C49.69999815293053%2C300%5D%2C350000%2C-90%2C-30%2C0%5D%2C%22cesium%22%2C%5B%22catalogConfig%22%2C%22LuxConfig%22%5D%2C%5B%5B%22basemap_2015_global%22%2C1%2C0%5D%2C%5B%22communes_labels%22%2C1%2C0%5D%2C%5B%22country%22%2C1%2C0%5D%2C%5B%22cantons%22%2C1%2C0%5D%5D%2C%5B%5D%2C0%5D'
         )
         .and('have.attr', 'target', 'lux3d')
     })

--- a/src/components/map-controls/map-3d.vue
+++ b/src/components/map-controls/map-3d.vue
@@ -58,13 +58,9 @@ const linkTo3dMap = computed(() => {
     ? JSON.stringify([bgLayer.value.name, 1, 0])
     : null
   if (selectedBgLayer) selectedLayers.unshift(selectedBgLayer)
-  const state = `[[[${[lon, lat, altitude].join(',')}],[${[
-    lon,
-    lat,
-    altitude,
-  ].join(
+  const state = `[[[],[${[lon, lat, 300].join(
     ','
-  )}],300,${heading},${LUX_VCS_PITCH},0],"cesium",["${LUX_VCS_MODULES.join(
+  )}],${altitude},${heading},${LUX_VCS_PITCH},0],"cesium",["${LUX_VCS_MODULES.join(
     '","'
   )}"],[${selectedLayers.join(',')}],[],0]`
 


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-810

### Description

PR is a follow up on #297 to keep the same ground position in center as in 2d by

- not indicating any camera position
- using altitude as distance to camera position
- using 300m as approximate avg lux terrain altitude

### Screenshots

<img width="1921" height="1031" alt="image" src="https://github.com/user-attachments/assets/6be6b612-2efb-43a6-b1ed-0ba165f17ec3" />


<img width="1921" height="1031" alt="image" src="https://github.com/user-attachments/assets/c97bf88e-887f-49cc-ba34-0ef446262c72" />

